### PR TITLE
Update appveyor and Cirrus settings.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,36 +5,42 @@ environment:
   - MSYSTEM: MINGW64
     CPU: x86_64
     MSVC: amd64
-    CONFIG_FLAGS: --enable-debug --enable-limit-usize-gap
+    CONFIG_FLAGS: --enable-debug
   - MSYSTEM: MINGW64
     CPU: x86_64
-    CONFIG_FLAGS: --enable-debug --enable-limit-usize-gap
+    CONFIG_FLAGS: --enable-debug
+    EXTRA_CFLAGS: "-fcommon"
   - MSYSTEM: MINGW32
     CPU: i686
     MSVC: x86
-    CONFIG_FLAGS: --enable-debug --enable-limit-usize-gap
+    CONFIG_FLAGS: --enable-debug
   - MSYSTEM: MINGW32
     CPU: i686
-    CONFIG_FLAGS: --enable-debug --enable-limit-usize-gap
+    CONFIG_FLAGS: --enable-debug
+    EXTRA_CFLAGS: "-fcommon"
   - MSYSTEM: MINGW64
     CPU: x86_64
     MSVC: amd64
-    CONFIG_FLAGS: --enable-limit-usize-gap
+    CONFIG_FLAGS:
   - MSYSTEM: MINGW64
     CPU: x86_64
-    CONFIG_FLAGS: --enable-limit-usize-gap
+    CONFIG_FLAGS:
+    EXTRA_CFLAGS: "-fcommon"
   - MSYSTEM: MINGW32
     CPU: i686
     MSVC: x86
-    CONFIG_FLAGS: --enable-limit-usize-gap
+    CONFIG_FLAGS:
   - MSYSTEM: MINGW32
     CPU: i686
-    CONFIG_FLAGS: --enable-limit-usize-gap
+    CONFIG_FLAGS:
+    EXTRA_CFLAGS: "-fcommon"
 
 install:
   - set PATH=c:\msys64\%MSYSTEM%\bin;c:\msys64\usr\bin;%PATH%
   - if defined MSVC call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %MSVC%
   - if defined MSVC pacman --noconfirm -Rsc mingw-w64-%CPU%-gcc gcc
+  - pacman --noconfirm -Syuu
+  - pacman --noconfirm -S autoconf
 
 build_script:
   - bash -c "autoconf"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,7 +40,7 @@ task:
     # We don't perfectly track freebsd stdlib.h definitions.  This is fine when
     # we count as a system header, but breaks otherwise, like during these
     # tests.
-    - ./configure --with-jemalloc-prefix=ci_ --enable-limit-usize-gap ${DEBUG_CONFIG} ${PROF_CONFIG} ${UNCOMMON_CONFIG}
+    - ./configure --with-jemalloc-prefix=ci_ ${DEBUG_CONFIG} ${PROF_CONFIG} ${UNCOMMON_CONFIG}
     - export JFLAG=`sysctl -n kern.smp.cpus`
     - gmake -j${JFLAG}
     - gmake -j${JFLAG} tests


### PR DESCRIPTION
Updated both appveyor and Cirrus settings.

For appveyor, two things fixed:
1. Added commands to install `autoconf`
2. gcc used does not have `-fcommon` enabled by default. Added the flag for gcc usage in Windows test (where no MSVC is specified) to handle multi-defined symbols like `malloc_conf` properly.

For Cirrus, the build-time config `--enable-limit-usize-gap` is removed in a previous [PR](https://github.com/jemalloc/jemalloc/pull/2835), removed it in CIrrus tests.
