### PR TITLE
[sdt] Add some tracepoints to sec and hpa modules

### DIFF
--- a/src/hpdata.c
+++ b/src/hpdata.c
@@ -2,7 +2,6 @@
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
 #include "jemalloc/internal/hpdata.h"
-#include "jemalloc/internal/jemalloc_probe.h"
 
 static int
 hpdata_age_comp(const hpdata_t *a, const hpdata_t *b) {
@@ -102,8 +101,6 @@ hpdata_reserve_alloc(hpdata_t *hpdata, size_t sz) {
 	    hpdata->touched_pages, HUGEPAGE_PAGES, result, npages);
 	fb_set_range(hpdata->touched_pages, HUGEPAGE_PAGES, result, npages);
 	hpdata->h_ntouched += new_dirty;
-	JE_USDT(hpa_reserve, 5, npages, hpdata->h_nactive, hpdata->h_ntouched,
-	    new_dirty, largest_unchosen_range);
 
 	/*
 	 * If we allocated out of a range that was the longest in the hpdata, it
@@ -164,8 +161,6 @@ hpdata_unreserve(hpdata_t *hpdata, void *addr, size_t sz) {
 	hpdata->h_nactive -= npages;
 
 	hpdata_assert_consistent(hpdata);
-	JE_USDT(hpa_unreserve, 5, npages, hpdata->h_nactive, hpdata->h_ntouched,
-	    old_longest_range, new_range_len);
 }
 
 size_t

--- a/src/sec.c
+++ b/src/sec.c
@@ -2,6 +2,7 @@
 #include "jemalloc/internal/jemalloc_internal_includes.h"
 
 #include "jemalloc/internal/sec.h"
+#include "jemalloc/internal/jemalloc_probe.h"
 
 static edata_t *sec_alloc(tsdn_t *tsdn, pai_t *self, size_t size,
     size_t alignment, bool zero, bool guarded, bool frequent_reuse,
@@ -266,6 +267,7 @@ sec_alloc(tsdn_t *tsdn, pai_t *self, size_t size, size_t alignment, bool zero,
 			    deferred_work_generated);
 		}
 	}
+	JE_USDT(sec_alloc, 5, sec, shard, edata, size, frequent_reuse);
 	return edata;
 }
 
@@ -273,6 +275,7 @@ static bool
 sec_expand(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
     size_t new_size, bool zero, bool *deferred_work_generated) {
 	sec_t *sec = (sec_t *)self;
+	JE_USDT(sec_expand, 4, sec, edata, old_size, new_size);
 	return pai_expand(tsdn, sec->fallback, edata, old_size, new_size, zero,
 	    deferred_work_generated);
 }
@@ -281,6 +284,7 @@ static bool
 sec_shrink(tsdn_t *tsdn, pai_t *self, edata_t *edata, size_t old_size,
     size_t new_size, bool *deferred_work_generated) {
 	sec_t *sec = (sec_t *)self;
+	JE_USDT(sec_shrink, 4, sec, edata, old_size, new_size);
 	return pai_shrink(tsdn, sec->fallback, edata, old_size, new_size,
 	    deferred_work_generated);
 }
@@ -351,6 +355,7 @@ sec_dalloc(
 		return;
 	}
 	sec_shard_t *shard = sec_shard_pick(tsdn, sec);
+	JE_USDT(sec_dalloc, 3, sec, shard, edata);
 	malloc_mutex_lock(tsdn, &shard->mtx);
 	if (shard->enabled) {
 		sec_shard_dalloc_and_unlock(tsdn, sec, shard, edata);


### PR DESCRIPTION
Ads few more tracepoints to sec and hpa modules.  Example usage:

```
# example.bt

usdt:*:jemalloc:hpa_update_purge_hugify_eligibility
{
        print((
            ("huge_page", arg0),
            ("nactive", arg1),
            ("ndirty", arg2),
            ("is_huge", arg3)
        ));
}
```

`sudo bpftrace -p `pidof my_prog` example.bt`

Gives output like this
 
```
Attached 2 probes
((huge_page, 139956313912192), (nactive, 73), (ndirty, 0), (is_huge, 0))
((huge_page, 139956309376512), (nactive, 195), (ndirty, 7), (is_huge, 0))
((huge_page, 139956309376512), (nactive, 188), (ndirty, 14), (is_huge, 0))
...
```