### PR TITLE
Provide hugepage advice only when the THP enabled setting is madvise

### DIFF
--- a/src/hpa.c
+++ b/src/hpa.c
@@ -716,7 +716,8 @@ hpa_shard_maybe_do_deferred_work(
 	 * Try to hugify at least once, even if we out of operations to make at
 	 * least some progress on hugification even at worst case.
 	 */
-	while (hpa_try_hugify(tsdn, shard) && nops < max_ops) {
+	while (init_system_thp_mode == thp_mode_default &&
+	       hpa_try_hugify(tsdn, shard) && nops < max_ops) {
 		malloc_mutex_assert_owner(tsdn, &shard->mtx);
 		nops++;
 	}


### PR DESCRIPTION
When THP is enabled system-wide, there is no need to provide hugepage
advice to enable THP for a region of memory.  On the other hand, when
the THP defragmentation mode is defer+madvise, hugepage advice can
result in unwanted application stalls to compact and defragment memory
if THP is not immediately available for allocation.
