### PR TITLE
Fix the compilation check for process madvise

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2633,8 +2633,8 @@ if test "x${je_cv_madvise}" = "xyes" ; then
 
   dnl Check for process_madvise
   JE_COMPILABLE([process_madvise(2)], [
-#include <sys/mman.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 ], [
 	syscall(SYS_process_madvise, 0, (void *)0, 0, 0, 0);
 ], [je_cv_process_madvise])


### PR DESCRIPTION
An include of unistd.h is needed to make the declaration of the syscall function visible to the compiler.  The include of sys/mman.h is not used at all.