### PR TITLE
Change the default page size to 64KiB on Aarch64 Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1990,6 +1990,11 @@ case "${host}" in
         LG_PAGE=14
       fi
       ;;
+  aarch64-unknown-linux-*)
+      if test "x$LG_PAGE" = "xdetect"; then
+        LG_PAGE=16
+      fi
+      ;;
 esac
 if test "x$LG_PAGE" = "xdetect"; then
   AC_CACHE_CHECK([LG_PAGE],
@@ -3076,6 +3081,8 @@ AC_MSG_RESULT([DATADIR            : ${DATADIR}])
 AC_MSG_RESULT([INCLUDEDIR         : ${INCLUDEDIR}])
 AC_MSG_RESULT([LIBDIR             : ${LIBDIR}])
 AC_MSG_RESULT([MANDIR             : ${MANDIR}])
+AC_MSG_RESULT([])
+AC_MSG_RESULT([LG_PAGE            : ${LG_PAGE}])
 AC_MSG_RESULT([])
 AC_MSG_RESULT([srcroot            : ${srcroot}])
 AC_MSG_RESULT([abs_srcroot        : ${abs_srcroot}])


### PR DESCRIPTION
This updates the configuration script to set the default page size to 64KiB on Aarch64 Linux.  This is motivated by compatibility as a build configured for a 64KiB page will work on kernels that use the smaller 4KiB or 16KiB pages, whereas the reverse is not true.

To make the configured page size setting more visible, the script now displays the page size when printing the configuration results.

Users that want to override the page size in to choose a smaller value can still do so with the --with-lg-pagesize configuration option.