### PR TITLE
Remove pidfd_open call handling and rely on PIDFD_SELF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2638,10 +2638,11 @@ if test "x${je_cv_madvise}" = "xyes" ; then
 
   dnl Check for process_madvise
   JE_COMPILABLE([process_madvise(2)], [
+#include <sys/pidfd.h>
 #include <sys/syscall.h>
 #include <unistd.h>
 ], [
-	syscall(SYS_process_madvise, 0, (void *)0, 0, 0, 0);
+	syscall(SYS_process_madvise, PIDFD_SELF, (void *)0, 0, 0, 0);
 ], [je_cv_process_madvise])
   if test "x${je_cv_process_madvise}" = "xyes" ; then
     AC_DEFINE([JEMALLOC_HAVE_PROCESS_MADVISE], [ ], [ ])

--- a/include/jemalloc/internal/pages.h
+++ b/include/jemalloc/internal/pages.h
@@ -127,6 +127,5 @@ bool pages_boot(void);
 void pages_set_thp_state(void *ptr, size_t size);
 void pages_mark_guards(void *head, void *tail);
 void pages_unmark_guards(void *head, void *tail);
-void pages_postfork_child(void);
 
 #endif /* JEMALLOC_INTERNAL_PAGES_EXTERNS_H */

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -4535,7 +4535,6 @@ jemalloc_postfork_child(void) {
 	malloc_mutex_postfork_child(tsd_tsdn(tsd), &arenas_lock);
 	tcache_postfork_child(tsd_tsdn(tsd));
 	ctl_postfork_child(tsd_tsdn(tsd));
-	pages_postfork_child();
 }
 
 /******************************************************************************/

--- a/src/pages.c
+++ b/src/pages.c
@@ -621,7 +621,11 @@ pages_dodump(void *addr, size_t size) {
 #ifdef JEMALLOC_HAVE_PROCESS_MADVISE
 #	include <sys/mman.h>
 #	include <sys/syscall.h>
-static atomic_i_t process_madvise_pidfd = ATOMIC_INIT(-1);
+
+#ifndef PIDFD_SELF
+#define PIDFD_SELF -10000
+#endif
+
 static atomic_b_t process_madvise_gate = ATOMIC_INIT(true);
 
 static bool
@@ -650,33 +654,17 @@ pages_purge_process_madvise_impl(
 	if (!atomic_load_b(&process_madvise_gate, ATOMIC_RELAXED)) {
 		return true;
 	}
-	int pid_fd = atomic_load_i(&process_madvise_pidfd, ATOMIC_RELAXED);
-	while (pid_fd == -1) {
-		int newfd = (int) syscall(SYS_pidfd_open, getpid(), 0);
-		if (newfd == -1) {
-			return true;
-		}
-		if (!atomic_compare_exchange_strong_i(&process_madvise_pidfd,
-						      &pid_fd, newfd,
-						      ATOMIC_RELAXED,
-						      ATOMIC_RELAXED)) {
-			/* Someone else set the fd, so we close ours */
-			assert(pid_fd != -1);
-			close(newfd);
-		} else {
-			pid_fd = newfd;
-		}
-	}
 
 	/*
 	 * TODO: remove this save/restore of errno after supporting errno
 	 * preservation for free() call properly.
 	 */
 	int saved_errno = get_errno();
-	size_t purged_bytes = (size_t)syscall(JE_SYS_PROCESS_MADVISE_NR, pid_fd,
-	    (struct iovec *)vec, vec_len, MADV_DONTNEED, 0);
+	size_t purged_bytes = (size_t)syscall(JE_SYS_PROCESS_MADVISE_NR,
+	    PIDFD_SELF, (struct iovec *)vec, vec_len, MADV_DONTNEED, 0);
 	if (purged_bytes == (size_t) -1) {
-		if (errno == EPERM || errno == EINVAL || errno == ENOSYS) {
+		if (errno == EPERM || errno == EINVAL || errno == ENOSYS
+		    || errno == EBADF) {
 			/* Process madvise not supported the way we need it. */
 			atomic_store_b(&process_madvise_gate, false,
 				       ATOMIC_RELAXED);
@@ -685,15 +673,6 @@ pages_purge_process_madvise_impl(
 	}
 
 	return purged_bytes != total_bytes;
-}
-
-void pages_postfork_child(void) {
-	/* Reset the file descriptor we inherited from parent process */
-	int pid_fd = atomic_load_i(&process_madvise_pidfd, ATOMIC_RELAXED);
-	if (pid_fd != -1) {
-		atomic_store_i(&process_madvise_pidfd, -1, ATOMIC_RELAXED);
-		close(pid_fd);
-	}
 }
 
 #else
@@ -709,8 +688,6 @@ pages_purge_process_madvise_impl(
 	not_reached();
 	return true;
 }
-
-void pages_postfork_child(void) {}
 
 #endif
 


### PR DESCRIPTION
**Motivation**
There are several reasons that motivate this change:
-    Avoid lazy initialization pidfd_open call as that creates the need for `mallctl` to deterministically  control the invocation so that tests in libraries like folly, or binaries like python that are trying to catch leaking file descriptors do not get unlucky. 
- Avoid eager initialization as for small binaries it may result in unnecessary initialization cost. Also, it avoids the need to `dup()` the file descriptor until it is not 0,1,2 as that can confuse programs that close stdout,stderr, or stdin (for example some CPython tests close the stream between `fork()` and `exec()` and assert that file descriptor with that number if open is result of some error.
- Avoid one more syscall
- Delete `pages_postfork` work

Downside:
- One would have to wait for kernel [patch](https://github.com/torvalds/linux/commit/f08d0c3a71114bb36d1722506d926bd497182781)  to start using this functionality

**Changes**
Deleted postfork invocation from jemalloc.c, and changed `src/pages.c` to use PIDFD_SELF with process_madvise call (added handling of EBADF errno).

**Testing**
Tested internally by forcing `--with-experimental-sys-process-madvise=440` on 6.13 kernel with backported functionality and it works as expected.
Tested on non-supported kernels (6.9 and 6.11) and call returns EBADF and falls back into `madvise` call.
