### PR TITLE
Always use pthread_equal to compare thread IDs

### DIFF
--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -220,7 +220,8 @@ static uint8_t malloc_slow_flags;
 /* Used to let the initializing thread recursively allocate. */
 #	define NO_INITIALIZER ((unsigned long)0)
 #	define INITIALIZER pthread_self()
-#	define IS_INITIALIZER (malloc_initializer == pthread_self())
+#	define IS_INITIALIZER                                                 \
+		(pthread_equal(malloc_initializer, pthread_self()))
 static pthread_t malloc_initializer = NO_INITIALIZER;
 #else
 #	define NO_INITIALIZER false

--- a/src/tsd.c
+++ b/src/tsd.c
@@ -528,7 +528,7 @@ tsd_init_check_recursion(tsd_init_head_t *head, tsd_init_block_t *block) {
 	/* Check whether this thread has already inserted into the list. */
 	malloc_mutex_lock(TSDN_NULL, &head->lock);
 	ql_foreach (iter, &head->blocks, link) {
-		if (iter->thread == self) {
+		if (pthread_equal(iter->thread, self)) {
 			malloc_mutex_unlock(TSDN_NULL, &head->lock);
 			return iter->data;
 		}


### PR DESCRIPTION
This change replaces direct comparisons of Pthread thread IDs with calls to pthread_equal.  Directly comparing thread IDs is neither portable nor reliable since a thread ID is defined as an opaque type that can be implemented using a structure.