### PR TITLE
Fix wrong array address if alloca() is used

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -448,7 +448,7 @@ background_thread0_work(tsd_t *tsd) {
 		}
 		if (check_background_thread_creation(tsd,
 		        const_max_background_threads, &n_created,
-		        (bool *)&created_threads)) {
+		        &created_threads[0])) {
 			continue;
 		}
 		background_work_sleep_once(


### PR DESCRIPTION
Reported at https://github.com/facebook/jemalloc/issues/59