### PR TITLE
Remove an incorrect use of the address operator

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -448,7 +448,7 @@ background_thread0_work(tsd_t *tsd) {
 		}
 		if (check_background_thread_creation(tsd,
 		        const_max_background_threads, &n_created,
-		        (bool *)&created_threads)) {
+		        created_threads)) {
 			continue;
 		}
 		background_work_sleep_once(


### PR DESCRIPTION
The address of the local variable created_threads is a different location than the data it points to.  Incorrectly treating these values as being the same can cause out-of-bounds writes to the stack.

Resolves #59

Before this commit:
Run `make clean && ./configure CFLAGS="-D__STDC_NO_VLA__" && make -j64 && make tests -j64 && make check -j64` 
We will get the error message: `expect_deferred_purging:test/unit/hpa_background_thread.c:177: Failed assertion: (0) == (empty_ndirty) --> 0 != 1: Should have seen a background purge`

After this commit, running the same command results in no errors.