### PR TITLE
Fix background thread initialization race

### DIFF
--- a/src/background_thread.c
+++ b/src/background_thread.c
@@ -547,8 +547,11 @@ background_thread_create_locked(tsd_t *tsd, unsigned arena_ind) {
 	if (!need_new_thread) {
 		return false;
 	}
-	if (arena_ind != 0) {
-		/* Threads are created asynchronously by Thread 0. */
+	if (thread_ind != 0) {
+		/*
+		 * Non-zero thread slots are created asynchronously by Thread 0.
+		 * Only thread 0 is created directly (by whoever needs it first).
+		 */
 		background_thread_info_t *t0 = &background_thread_info[0];
 		malloc_mutex_lock(tsd_tsdn(tsd), &t0->mtx);
 		assert(t0->state == background_thread_started);


### PR DESCRIPTION
 The race condition happens when per-cpu arenas and background threads features are enabled:

  1. Thread A calls `malloc()` first -> starts `malloc_init_hard()`
  2. While Thread A is still in `malloc_init_hard()`, Threads B, C, D also call `malloc()`
  3. These threads trigger arena creation (with percpu_arena, each CPU gets its own arena)
  4. `arena_init()` -> `arena_new_create_background_thread()` -> `background_thread_create(arena_ind=12, etc.)`
  5. Thread A hasn't reached line 2232 (`background_thread_create(tsd, 0)`) yet
  6. So a non-zero arena can mark thread slot 0 as "started" before arena 0 does

 The initialization has locks, but arena creation for different arenas can proceed in parallel as soon as `malloc_init_state = initialized` and `init_lock` is released, and the `background_thread_create(tsd, 0)` call happens late in `malloc_init_hard()` (after arenas are already being created by other threads).

This bug won't be noticeable for applications that have single-threaded initialization path, but in case of JVM it's easily reproducible. When background thread initialization silently fails due to the race, RSS grows infinitely until the process gets OOM killed.