### PR TITLE
Determine the page size on Android from NDK header files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1990,6 +1990,11 @@ case "${host}" in
         LG_PAGE=14
       fi
       ;;
+  *-*-linux-android)
+      if test "x$LG_PAGE" = "xdetect"; then
+	AC_CHECK_DECLS([PAGE_SIZE], [LG_PAGE=12], [LG_PAGE=14], [#include <sys/user.h>])
+      fi
+      ;;
   aarch64-unknown-linux-*)
       if test "x$LG_PAGE" = "xdetect"; then
         LG_PAGE=16


### PR DESCRIPTION
The definition of the PAGE_SIZE macro is used as a signal for a 32-bit target or a 64-bit target with an older NDK.  Otherwise, a 16KiB page size is assumed.

Resolves jemalloc/jemalloc#2657