### PR TITLE
Revert "Experimental configuration option for fast path prefetch from…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1434,36 +1434,6 @@ if test "x$enable_experimental_smallocx" = "x1" ; then
 fi
 AC_SUBST([enable_experimental_smallocx])
 
-dnl Do not enable fastpath prefetch by default.
-AC_ARG_ENABLE([experimental_fp_prefetch],
-  [AS_HELP_STRING([--enable-experimental-fp-prefetch], [Enable experimental fastpath prefetch])],
-[if test "x$enable_experimental_fp_prefetch" = "xno" ; then
-enable_experimental_fp_prefetch="0"
-else
-  dnl Check if we have __builtin_prefetch.
-  JE_CFLAGS_SAVE()
-  JE_CFLAGS_ADD([-Werror=implicit-function-declaration])
-  JE_COMPILABLE([builtin prefetch], [], [
-void foo(void *p) { __builtin_prefetch(p, 1, 3); }
-  	],
-	[je_cv_have_builtin_prefetch])
-
-	if test "x${je_cv_have_builtin_prefetch}" = "xyes" ; then
-	   enable_experimental_fp_prefetch="1"
-	else
-	   enable_experimental_fp_prefetch="0"
-	   AC_MSG_ERROR([--enable--experimental-fp-prefetch can only be used when builtin_preftech is available])
-	fi
-   JE_CFLAGS_RESTORE()
-fi
-],
-[enable_experimental_fp_prefetch="0"]
-)
-if test "x$enable_experimental_fp_prefetch" = "x1" ; then
-  AC_DEFINE([JEMALLOC_EXPERIMENTAL_FASTPATH_PREFETCH], [ ], [ ])
-fi
-AC_SUBST([enable_experimental_fp_prefetch])
-
 dnl Do not enable profiling by default.
 AC_ARG_ENABLE([prof],
   [AS_HELP_STRING([--enable-prof], [Enable allocation profiling])],

--- a/include/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/include/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -160,11 +160,6 @@
 /* JEMALLOC_EXPERIMENTAL_SMALLOCX_API enables experimental smallocx API. */
 #undef JEMALLOC_EXPERIMENTAL_SMALLOCX_API
 
-/* JEMALLOC_EXPERIMENTAL_FASTPATH_PREFETCH enables prefetch
- * on malloc fast path.
- */
-#undef JEMALLOC_EXPERIMENTAL_FASTPATH_PREFETCH
-
 /* JEMALLOC_PROF enables allocation profiling. */
 #undef JEMALLOC_PROF
 

--- a/include/jemalloc/internal/jemalloc_internal_inlines_c.h
+++ b/include/jemalloc/internal/jemalloc_internal_inlines_c.h
@@ -374,12 +374,6 @@ imalloc_fastpath(size_t size, void *(fallback_alloc)(size_t)) {
 	 */
 	ret = cache_bin_alloc_easy(bin, &tcache_success);
 	if (tcache_success) {
-#if defined(JEMALLOC_EXPERIMENTAL_FASTPATH_PREFETCH)
-		cache_bin_sz_t lb = (cache_bin_sz_t)(uintptr_t)bin->stack_head;
-		if(likely(lb != bin->low_bits_empty)) {
-			util_prefetch_write_range(*(bin->stack_head), usize);
-		}
-#endif
 		fastpath_success_finish(tsd, allocated_after, bin, ret);
 		return ret;
 	}


### PR DESCRIPTION
… cache_bin"

This reverts commit f9fae9f1f841f8c6c566746480865da8ae3a1d11.

**Motivation**
More extensive experimentation did not show improvement, so we will bre removing this experimental feature to simplify the code.

**Changes**
Revert of the original commit. 

**Testing**
`make -j32 && make tests -j32 && make check -j32`
CI should do the rest.