### PR TITLE
Run single subtest from a test file

### DIFF
--- a/test/include/test/test.h
+++ b/test/include/test/test.h
@@ -520,12 +520,15 @@ typedef void(test_t)(void);
 
 #define TEST_BEGIN(f)                                                          \
 	static void f(void) {                                                  \
-		p_test_init(#f);
+		const bool skip_test = p_test_init(#f);                        \
+		if (skip_test) {                                               \
+			goto label_test_end;                                   \
+		}
 
 #define TEST_END                                                               \
 	goto label_test_end;                                                   \
 	label_test_end:                                                        \
-	p_test_fini();                                                         \
+	p_test_fini(skip_test);                                                \
 	}
 
 #define test(...) p_test(__VA_ARGS__, NULL)
@@ -552,6 +555,6 @@ void test_fail(const char *format, ...) JEMALLOC_FORMAT_PRINTF(1, 2);
 test_status_t p_test(test_t *t, ...);
 test_status_t p_test_no_reentrancy(test_t *t, ...);
 test_status_t p_test_no_malloc_init(test_t *t, ...);
-void          p_test_init(const char *name);
-void          p_test_fini(void);
+bool          p_test_init(const char *name);
+void          p_test_fini(bool skip_test);
 void p_test_fail(bool may_abort, const char *prefix, const char *message);

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -6,6 +6,7 @@ static unsigned      test_count = 0;
 static test_status_t test_counts[test_status_count] = {0, 0, 0};
 static test_status_t test_status = test_status_pass;
 static const char   *test_name = "";
+static const char   *selected_test_name = NULL;
 
 /* Reentrancy testing helpers. */
 
@@ -100,15 +101,26 @@ test_status_string(test_status_t current_status) {
 	}
 }
 
-void
+bool
 p_test_init(const char *name) {
+	if (selected_test_name != NULL && strcmp(selected_test_name, name)) {
+		/* skip test */
+		return true;
+	}
+
 	test_count++;
 	test_status = test_status_pass;
 	test_name = name;
+
+	return false;
 }
 
 void
-p_test_fini(void) {
+p_test_fini(bool skip_test) {
+	if (skip_test) {
+		return;
+	}
+
 	test_counts[test_status]++;
 	malloc_printf("%s (%s): %s\n", test_name, reentrancy_t_str(reentrancy),
 	    test_status_string(test_status));
@@ -130,6 +142,8 @@ check_global_slow(test_status_t *status) {
 
 static test_status_t
 p_test_impl(bool do_malloc_init, bool do_reentrant, test_t *t, va_list ap) {
+	selected_test_name = getenv("JEMALLOC_TEST_NAME");
+
 	test_status_t ret;
 
 	if (do_malloc_init) {


### PR DESCRIPTION
Add mechanism to be able to select one or more tests to run from a test file. The test harness will read JEMALLOC_TEST_REGEX env and, if set, compile it as a regex. It will then only run tests whose name match the regex.