### PR TITLE
Arena bins cleanup

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -208,6 +208,7 @@ TESTS_UNIT := \
 	$(srcroot)test/unit/background_thread_enable.c \
 	$(srcroot)test/unit/base.c \
 	$(srcroot)test/unit/batch_alloc.c \
+	$(srcroot)test/unit/bin.c \
 	$(srcroot)test/unit/binshard.c \
 	$(srcroot)test/unit/bitmap.c \
 	$(srcroot)test/unit/bit_util.c \

--- a/include/jemalloc/internal/arena_externs.h
+++ b/include/jemalloc/internal/arena_externs.h
@@ -79,10 +79,6 @@ void arena_dalloc_promoted(
     tsdn_t *tsdn, void *ptr, tcache_t *tcache, bool slow_path);
 void arena_slab_dalloc(tsdn_t *tsdn, arena_t *arena, edata_t *slab);
 
-void arena_dalloc_bin_locked_handle_newly_empty(
-    tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin);
-void arena_dalloc_bin_locked_handle_newly_nonempty(
-    tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin);
 void  arena_dalloc_small(tsdn_t *tsdn, void *ptr);
 void  arena_ptr_array_flush(tsd_t *tsd, szind_t binind,
      cache_bin_ptr_array_t *arr, unsigned nflush, bool small,
@@ -111,8 +107,6 @@ void     arena_nthreads_dec(arena_t *arena, bool internal);
 arena_t *arena_new(tsdn_t *tsdn, unsigned ind, const arena_config_t *config);
 bool     arena_init_huge(tsdn_t *tsdn, arena_t *a0);
 arena_t *arena_choose_huge(tsd_t *tsd);
-bin_t   *arena_bin_choose(
-      tsdn_t *tsdn, arena_t *arena, szind_t binind, unsigned *binshard);
 size_t arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     void **ptrs, size_t nfill, bool zero);
 bool   arena_boot(sc_data_t *sc_data, base_t *base, bool hpa);

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -609,12 +609,12 @@ arena_dalloc_bin_locked_step(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
 
 	unsigned nfree = edata_nfree_get(slab);
 	if (nfree == bin_info->nregs) {
-		arena_dalloc_bin_locked_handle_newly_empty(
-		    tsdn, arena, slab, bin);
+		bin_dalloc_locked_handle_newly_empty(
+		    tsdn, arena_is_auto(arena), slab, bin);
 		return true;
 	} else if (nfree == 1 && slab != bin->slabcur) {
-		arena_dalloc_bin_locked_handle_newly_nonempty(
-		    tsdn, arena, slab, bin);
+		bin_dalloc_locked_handle_newly_nonempty(
+		    tsdn, arena_is_auto(arena), slab, bin);
 	}
 	return false;
 }

--- a/include/jemalloc/internal/arena_inlines_b.h
+++ b/include/jemalloc/internal/arena_inlines_b.h
@@ -4,6 +4,7 @@
 #include "jemalloc/internal/jemalloc_preamble.h"
 #include "jemalloc/internal/arena_externs.h"
 #include "jemalloc/internal/arena_structs.h"
+#include "jemalloc/internal/bin_inlines.h"
 #include "jemalloc/internal/div.h"
 #include "jemalloc/internal/emap.h"
 #include "jemalloc/internal/jemalloc_internal_inlines_b.h"
@@ -335,29 +336,6 @@ arena_dalloc_large(tsdn_t *tsdn, void *ptr, tcache_t *tcache, szind_t szind,
 	}
 }
 
-/* Find the region index of a pointer. */
-JEMALLOC_ALWAYS_INLINE size_t
-arena_slab_regind_impl(
-    div_info_t *div_info, szind_t binind, edata_t *slab, const void *ptr) {
-	size_t diff, regind;
-
-	/* Freeing a pointer outside the slab can cause assertion failure. */
-	assert((uintptr_t)ptr >= (uintptr_t)edata_addr_get(slab));
-	assert((uintptr_t)ptr < (uintptr_t)edata_past_get(slab));
-	/* Freeing an interior pointer can cause assertion failure. */
-	assert(((uintptr_t)ptr - (uintptr_t)edata_addr_get(slab))
-	        % (uintptr_t)bin_infos[binind].reg_size
-	    == 0);
-
-	diff = (size_t)((uintptr_t)ptr - (uintptr_t)edata_addr_get(slab));
-
-	/* Avoid doing division with a variable divisor. */
-	regind = div_compute(div_info, diff);
-	assert(regind < bin_infos[binind].nregs);
-	return regind;
-}
-
-/* Checks whether ptr is currently active in the arena. */
 JEMALLOC_ALWAYS_INLINE bool
 arena_tcache_dalloc_small_safety_check(tsdn_t *tsdn, void *ptr) {
 	if (!config_debug) {
@@ -367,10 +345,10 @@ arena_tcache_dalloc_small_safety_check(tsdn_t *tsdn, void *ptr) {
 	szind_t    binind = edata_szind_get(edata);
 	div_info_t div_info = arena_binind_div_info[binind];
 	/*
-	 * Calls the internal function arena_slab_regind_impl because the
+	 * Calls the internal function bin_slab_regind_impl because the
 	 * safety check does not require a lock.
 	 */
-	size_t regind = arena_slab_regind_impl(&div_info, binind, edata, ptr);
+	size_t regind = bin_slab_regind_impl(&div_info, binind, edata, ptr);
 	slab_data_t      *slab_data = edata_slab_data_get(edata);
 	const bin_info_t *bin_info = &bin_infos[binind];
 	assert(edata_nfree_get(edata) < bin_info->nregs);
@@ -548,84 +526,6 @@ arena_cache_oblivious_randomize(
 		    + random_offset);
 		assert(ALIGNMENT_ADDR2BASE(edata->e_addr, alignment)
 		    == edata->e_addr);
-	}
-}
-
-/*
- * The dalloc bin info contains just the information that the common paths need
- * during tcache flushes.  By force-inlining these paths, and using local copies
- * of data (so that the compiler knows it's constant), we avoid a whole bunch of
- * redundant loads and stores by leaving this information in registers.
- */
-typedef struct arena_dalloc_bin_locked_info_s arena_dalloc_bin_locked_info_t;
-struct arena_dalloc_bin_locked_info_s {
-	div_info_t div_info;
-	uint32_t   nregs;
-	uint64_t   ndalloc;
-};
-
-JEMALLOC_ALWAYS_INLINE size_t
-arena_slab_regind(arena_dalloc_bin_locked_info_t *info, szind_t binind,
-    edata_t *slab, const void *ptr) {
-	size_t regind = arena_slab_regind_impl(
-	    &info->div_info, binind, slab, ptr);
-	return regind;
-}
-
-JEMALLOC_ALWAYS_INLINE void
-arena_dalloc_bin_locked_begin(
-    arena_dalloc_bin_locked_info_t *info, szind_t binind) {
-	info->div_info = arena_binind_div_info[binind];
-	info->nregs = bin_infos[binind].nregs;
-	info->ndalloc = 0;
-}
-
-/*
- * Does the deallocation work associated with freeing a single pointer (a
- * "step") in between a arena_dalloc_bin_locked begin and end call.
- *
- * Returns true if arena_slab_dalloc must be called on slab.  Doesn't do
- * stats updates, which happen during finish (this lets running counts get left
- * in a register).
- */
-JEMALLOC_ALWAYS_INLINE bool
-arena_dalloc_bin_locked_step(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
-    arena_dalloc_bin_locked_info_t *info, szind_t binind, edata_t *slab,
-    void *ptr) {
-	const bin_info_t *bin_info = &bin_infos[binind];
-	size_t            regind = arena_slab_regind(info, binind, slab, ptr);
-	slab_data_t      *slab_data = edata_slab_data_get(slab);
-
-	assert(edata_nfree_get(slab) < bin_info->nregs);
-	/* Freeing an unallocated pointer can cause assertion failure. */
-	assert(bitmap_get(slab_data->bitmap, &bin_info->bitmap_info, regind));
-
-	bitmap_unset(slab_data->bitmap, &bin_info->bitmap_info, regind);
-	edata_nfree_inc(slab);
-
-	if (config_stats) {
-		info->ndalloc++;
-	}
-
-	unsigned nfree = edata_nfree_get(slab);
-	if (nfree == bin_info->nregs) {
-		bin_dalloc_locked_handle_newly_empty(
-		    tsdn, arena_is_auto(arena), slab, bin);
-		return true;
-	} else if (nfree == 1 && slab != bin->slabcur) {
-		bin_dalloc_locked_handle_newly_nonempty(
-		    tsdn, arena_is_auto(arena), slab, bin);
-	}
-	return false;
-}
-
-JEMALLOC_ALWAYS_INLINE void
-arena_dalloc_bin_locked_finish(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
-    arena_dalloc_bin_locked_info_t *info) {
-	if (config_stats) {
-		bin->stats.ndalloc += info->ndalloc;
-		assert(bin->stats.curregs >= (size_t)info->ndalloc);
-		bin->stats.curregs -= (size_t)info->ndalloc;
 	}
 }
 

--- a/include/jemalloc/internal/bin.h
+++ b/include/jemalloc/internal/bin.h
@@ -2,6 +2,7 @@
 #define JEMALLOC_INTERNAL_BIN_H
 
 #include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/bin_info.h"
 #include "jemalloc/internal/bin_stats.h"
 #include "jemalloc/internal/bin_types.h"
 #include "jemalloc/internal/edata.h"
@@ -60,6 +61,43 @@ bool bin_init(bin_t *bin);
 void bin_prefork(tsdn_t *tsdn, bin_t *bin);
 void bin_postfork_parent(tsdn_t *tsdn, bin_t *bin);
 void bin_postfork_child(tsdn_t *tsdn, bin_t *bin);
+
+/* Slab region allocation. */
+void *bin_slab_reg_alloc(edata_t *slab, const bin_info_t *bin_info);
+void  bin_slab_reg_alloc_batch(
+     edata_t *slab, const bin_info_t *bin_info, unsigned cnt, void **ptrs);
+
+/* Slab list management. */
+void     bin_slabs_nonfull_insert(bin_t *bin, edata_t *slab);
+void     bin_slabs_nonfull_remove(bin_t *bin, edata_t *slab);
+edata_t *bin_slabs_nonfull_tryget(bin_t *bin);
+void     bin_slabs_full_insert(bool is_auto, bin_t *bin, edata_t *slab);
+void     bin_slabs_full_remove(bool is_auto, bin_t *bin, edata_t *slab);
+
+/* Slab association / demotion. */
+void bin_dissociate_slab(bool is_auto, edata_t *slab, bin_t *bin);
+void bin_lower_slab(tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin);
+
+/* Deallocation helpers (called under bin lock). */
+void bin_dalloc_slab_prepare(tsdn_t *tsdn, edata_t *slab, bin_t *bin);
+void bin_dalloc_locked_handle_newly_empty(
+    tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin);
+void bin_dalloc_locked_handle_newly_nonempty(
+    tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin);
+
+/* Slabcur refill and allocation. */
+void  bin_refill_slabcur_with_fresh_slab(tsdn_t *tsdn, bin_t *bin,
+    szind_t binind, edata_t *fresh_slab);
+void *bin_malloc_with_fresh_slab(tsdn_t *tsdn, bin_t *bin,
+    szind_t binind, edata_t *fresh_slab);
+bool  bin_refill_slabcur_no_fresh_slab(tsdn_t *tsdn, bool is_auto,
+    bin_t *bin);
+void *bin_malloc_no_fresh_slab(tsdn_t *tsdn, bool is_auto, bin_t *bin,
+    szind_t binind);
+
+/* Bin selection. */
+bin_t *bin_choose(tsdn_t *tsdn, arena_t *arena, szind_t binind,
+    unsigned *binshard_p);
 
 /* Stats. */
 static inline void

--- a/include/jemalloc/internal/bin_inlines.h
+++ b/include/jemalloc/internal/bin_inlines.h
@@ -1,0 +1,112 @@
+#ifndef JEMALLOC_INTERNAL_BIN_INLINES_H
+#define JEMALLOC_INTERNAL_BIN_INLINES_H
+
+#include "jemalloc/internal/jemalloc_preamble.h"
+#include "jemalloc/internal/bin.h"
+#include "jemalloc/internal/bin_info.h"
+#include "jemalloc/internal/bitmap.h"
+#include "jemalloc/internal/div.h"
+#include "jemalloc/internal/edata.h"
+#include "jemalloc/internal/sc.h"
+
+/*
+ * The dalloc bin info contains just the information that the common paths need
+ * during tcache flushes.  By force-inlining these paths, and using local copies
+ * of data (so that the compiler knows it's constant), we avoid a whole bunch of
+ * redundant loads and stores by leaving this information in registers.
+ */
+typedef struct bin_dalloc_locked_info_s bin_dalloc_locked_info_t;
+struct bin_dalloc_locked_info_s {
+	div_info_t div_info;
+	uint32_t   nregs;
+	uint64_t   ndalloc;
+};
+
+/* Find the region index of a pointer within a slab. */
+JEMALLOC_ALWAYS_INLINE size_t
+bin_slab_regind_impl(
+    div_info_t *div_info, szind_t binind, edata_t *slab, const void *ptr) {
+	size_t diff, regind;
+
+	/* Freeing a pointer outside the slab can cause assertion failure. */
+	assert((uintptr_t)ptr >= (uintptr_t)edata_addr_get(slab));
+	assert((uintptr_t)ptr < (uintptr_t)edata_past_get(slab));
+	/* Freeing an interior pointer can cause assertion failure. */
+	assert(((uintptr_t)ptr - (uintptr_t)edata_addr_get(slab))
+	        % (uintptr_t)bin_infos[binind].reg_size
+	    == 0);
+
+	diff = (size_t)((uintptr_t)ptr - (uintptr_t)edata_addr_get(slab));
+
+	/* Avoid doing division with a variable divisor. */
+	regind = div_compute(div_info, diff);
+	assert(regind < bin_infos[binind].nregs);
+	return regind;
+}
+
+JEMALLOC_ALWAYS_INLINE size_t
+bin_slab_regind(bin_dalloc_locked_info_t *info, szind_t binind,
+    edata_t *slab, const void *ptr) {
+	size_t regind = bin_slab_regind_impl(
+	    &info->div_info, binind, slab, ptr);
+	return regind;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+bin_dalloc_locked_begin(
+    bin_dalloc_locked_info_t *info, szind_t binind) {
+	info->div_info = arena_binind_div_info[binind];
+	info->nregs = bin_infos[binind].nregs;
+	info->ndalloc = 0;
+}
+
+/*
+ * Does the deallocation work associated with freeing a single pointer (a
+ * "step") in between a bin_dalloc_locked begin and end call.
+ *
+ * Returns true if arena_slab_dalloc must be called on slab.  Doesn't do
+ * stats updates, which happen during finish (this lets running counts get left
+ * in a register).
+ */
+JEMALLOC_ALWAYS_INLINE bool
+bin_dalloc_locked_step(tsdn_t *tsdn, bool is_auto, bin_t *bin,
+    bin_dalloc_locked_info_t *info, szind_t binind, edata_t *slab,
+    void *ptr) {
+	const bin_info_t *bin_info = &bin_infos[binind];
+	size_t            regind = bin_slab_regind(info, binind, slab, ptr);
+	slab_data_t      *slab_data = edata_slab_data_get(slab);
+
+	assert(edata_nfree_get(slab) < bin_info->nregs);
+	/* Freeing an unallocated pointer can cause assertion failure. */
+	assert(bitmap_get(slab_data->bitmap, &bin_info->bitmap_info, regind));
+
+	bitmap_unset(slab_data->bitmap, &bin_info->bitmap_info, regind);
+	edata_nfree_inc(slab);
+
+	if (config_stats) {
+		info->ndalloc++;
+	}
+
+	unsigned nfree = edata_nfree_get(slab);
+	if (nfree == bin_info->nregs) {
+		bin_dalloc_locked_handle_newly_empty(
+		    tsdn, is_auto, slab, bin);
+		return true;
+	} else if (nfree == 1 && slab != bin->slabcur) {
+		bin_dalloc_locked_handle_newly_nonempty(
+		    tsdn, is_auto, slab, bin);
+	}
+	return false;
+}
+
+JEMALLOC_ALWAYS_INLINE void
+bin_dalloc_locked_finish(tsdn_t *tsdn, bin_t *bin,
+    bin_dalloc_locked_info_t *info) {
+	if (config_stats) {
+		bin->stats.ndalloc += info->ndalloc;
+		assert(bin->stats.curregs >= (size_t)info->ndalloc);
+		bin->stats.curregs -= (size_t)info->ndalloc;
+	}
+}
+
+#endif /* JEMALLOC_INTERNAL_BIN_INLINES_H */

--- a/src/arena.c
+++ b/src/arena.c
@@ -66,8 +66,6 @@ const arena_config_t arena_config_default = {
 
 static bool arena_decay_dirty(
     tsdn_t *tsdn, arena_t *arena, bool is_background_thread, bool all);
-static void arena_bin_lower_slab(
-    tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin);
 static void arena_maybe_do_deferred_work(
     tsdn_t *tsdn, arena_t *arena, decay_t *decay, size_t npages_new);
 
@@ -239,71 +237,6 @@ arena_handle_deferred_work(tsdn_t *tsdn, arena_t *arena) {
 		arena_decay_dirty(tsdn, arena, false, true);
 	}
 	arena_background_thread_inactivity_check(tsdn, arena, false);
-}
-
-static void *
-arena_slab_reg_alloc(edata_t *slab, const bin_info_t *bin_info) {
-	void        *ret;
-	slab_data_t *slab_data = edata_slab_data_get(slab);
-	size_t       regind;
-
-	assert(edata_nfree_get(slab) > 0);
-	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
-
-	regind = bitmap_sfu(slab_data->bitmap, &bin_info->bitmap_info);
-	ret = (void *)((byte_t *)edata_addr_get(slab)
-	    + (uintptr_t)(bin_info->reg_size * regind));
-	edata_nfree_dec(slab);
-	return ret;
-}
-
-static void
-arena_slab_reg_alloc_batch(
-    edata_t *slab, const bin_info_t *bin_info, unsigned cnt, void **ptrs) {
-	slab_data_t *slab_data = edata_slab_data_get(slab);
-
-	assert(edata_nfree_get(slab) >= cnt);
-	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
-
-#if (!defined JEMALLOC_INTERNAL_POPCOUNTL) || (defined BITMAP_USE_TREE)
-	for (unsigned i = 0; i < cnt; i++) {
-		size_t regind = bitmap_sfu(
-		    slab_data->bitmap, &bin_info->bitmap_info);
-		*(ptrs + i) = (void *)((uintptr_t)edata_addr_get(slab)
-		    + (uintptr_t)(bin_info->reg_size * regind));
-	}
-#else
-	unsigned group = 0;
-	bitmap_t g = slab_data->bitmap[group];
-	unsigned i = 0;
-	while (i < cnt) {
-		while (g == 0) {
-			g = slab_data->bitmap[++group];
-		}
-		size_t shift = group << LG_BITMAP_GROUP_NBITS;
-		size_t pop = popcount_lu(g);
-		if (pop > (cnt - i)) {
-			pop = cnt - i;
-		}
-
-		/*
-		 * Load from memory locations only once, outside the
-		 * hot loop below.
-		 */
-		uintptr_t base = (uintptr_t)edata_addr_get(slab);
-		uintptr_t regsize = (uintptr_t)bin_info->reg_size;
-		while (pop--) {
-			size_t bit = cfs_lu(&g);
-			size_t regind = shift + bit;
-			/* NOLINTNEXTLINE(performance-no-int-to-ptr) */
-			*(ptrs + i) = (void *)(base + regsize * regind);
-
-			i++;
-		}
-		slab_data->bitmap[group] = g;
-	}
-#endif
-	edata_nfree_sub(slab, cnt);
 }
 
 static void
@@ -623,58 +556,6 @@ arena_slab_dalloc(tsdn_t *tsdn, arena_t *arena, edata_t *slab) {
 }
 
 static void
-arena_bin_slabs_nonfull_insert(bin_t *bin, edata_t *slab) {
-	assert(edata_nfree_get(slab) > 0);
-	edata_heap_insert(&bin->slabs_nonfull, slab);
-	if (config_stats) {
-		bin->stats.nonfull_slabs++;
-	}
-}
-
-static void
-arena_bin_slabs_nonfull_remove(bin_t *bin, edata_t *slab) {
-	edata_heap_remove(&bin->slabs_nonfull, slab);
-	if (config_stats) {
-		bin->stats.nonfull_slabs--;
-	}
-}
-
-static edata_t *
-arena_bin_slabs_nonfull_tryget(bin_t *bin) {
-	edata_t *slab = edata_heap_remove_first(&bin->slabs_nonfull);
-	if (slab == NULL) {
-		return NULL;
-	}
-	if (config_stats) {
-		bin->stats.reslabs++;
-		bin->stats.nonfull_slabs--;
-	}
-	return slab;
-}
-
-static void
-arena_bin_slabs_full_insert(arena_t *arena, bin_t *bin, edata_t *slab) {
-	assert(edata_nfree_get(slab) == 0);
-	/*
-	 *  Tracking extents is required by arena_reset, which is not allowed
-	 *  for auto arenas.  Bypass this step to avoid touching the edata
-	 *  linkage (often results in cache misses) for auto arenas.
-	 */
-	if (arena_is_auto(arena)) {
-		return;
-	}
-	edata_list_active_append(&bin->slabs_full, slab);
-}
-
-static void
-arena_bin_slabs_full_remove(arena_t *arena, bin_t *bin, edata_t *slab) {
-	if (arena_is_auto(arena)) {
-		return;
-	}
-	edata_list_active_remove(&bin->slabs_full, slab);
-}
-
-static void
 arena_bin_reset(tsd_t *tsd, arena_t *arena, bin_t *bin) {
 	edata_t *slab;
 
@@ -694,7 +575,7 @@ arena_bin_reset(tsd_t *tsd, arena_t *arena, bin_t *bin) {
 	}
 	for (slab = edata_list_active_first(&bin->slabs_full); slab != NULL;
 	    slab = edata_list_active_first(&bin->slabs_full)) {
-		arena_bin_slabs_full_remove(arena, bin, slab);
+		bin_slabs_full_remove(false, bin, slab);
 		malloc_mutex_unlock(tsd_tsdn(tsd), &bin->lock);
 		arena_slab_dalloc(tsd_tsdn(tsd), arena, slab);
 		malloc_mutex_lock(tsd_tsdn(tsd), &bin->lock);
@@ -985,73 +866,6 @@ arena_slab_alloc(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 	return slab;
 }
 
-/*
- * Before attempting the _with_fresh_slab approaches below, the _no_fresh_slab
- * variants (i.e. through slabcur and nonfull) must be tried first.
- */
-static void
-arena_bin_refill_slabcur_with_fresh_slab(tsdn_t *tsdn, arena_t *arena,
-    bin_t *bin, szind_t binind, edata_t *fresh_slab) {
-	malloc_mutex_assert_owner(tsdn, &bin->lock);
-	/* Only called after slabcur and nonfull both failed. */
-	assert(bin->slabcur == NULL);
-	assert(edata_heap_first(&bin->slabs_nonfull) == NULL);
-	assert(fresh_slab != NULL);
-
-	/* A new slab from arena_slab_alloc() */
-	assert(edata_nfree_get(fresh_slab) == bin_infos[binind].nregs);
-	if (config_stats) {
-		bin->stats.nslabs++;
-		bin->stats.curslabs++;
-	}
-	bin->slabcur = fresh_slab;
-}
-
-/* Refill slabcur and then alloc using the fresh slab */
-static void *
-arena_bin_malloc_with_fresh_slab(tsdn_t *tsdn, arena_t *arena, bin_t *bin,
-    szind_t binind, edata_t *fresh_slab) {
-	malloc_mutex_assert_owner(tsdn, &bin->lock);
-	arena_bin_refill_slabcur_with_fresh_slab(
-	    tsdn, arena, bin, binind, fresh_slab);
-
-	return arena_slab_reg_alloc(bin->slabcur, &bin_infos[binind]);
-}
-
-static bool
-arena_bin_refill_slabcur_no_fresh_slab(
-    tsdn_t *tsdn, arena_t *arena, bin_t *bin) {
-	malloc_mutex_assert_owner(tsdn, &bin->lock);
-	/* Only called after arena_slab_reg_alloc[_batch] failed. */
-	assert(bin->slabcur == NULL || edata_nfree_get(bin->slabcur) == 0);
-
-	if (bin->slabcur != NULL) {
-		arena_bin_slabs_full_insert(arena, bin, bin->slabcur);
-	}
-
-	/* Look for a usable slab. */
-	bin->slabcur = arena_bin_slabs_nonfull_tryget(bin);
-	assert(bin->slabcur == NULL || edata_nfree_get(bin->slabcur) > 0);
-
-	return (bin->slabcur == NULL);
-}
-
-bin_t *
-arena_bin_choose(
-    tsdn_t *tsdn, arena_t *arena, szind_t binind, unsigned *binshard_p) {
-	unsigned binshard;
-	if (tsdn_null(tsdn) || tsd_arena_get(tsdn_tsd(tsdn)) == NULL) {
-		binshard = 0;
-	} else {
-		binshard = tsd_binshardsp_get(tsdn_tsd(tsdn))->binshard[binind];
-	}
-	assert(binshard < bin_infos[binind].n_shards);
-	if (binshard_p != NULL) {
-		*binshard_p = binshard;
-	}
-	return arena_get_bin(arena, binind, binshard);
-}
-
 cache_bin_sz_t
 arena_ptr_array_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind,
     cache_bin_ptr_array_t *arr, const cache_bin_sz_t nfill_min,
@@ -1088,9 +902,10 @@ arena_ptr_array_fill_small(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 	bool           made_progress = true;
 	edata_t       *fresh_slab = NULL;
 	bool           alloc_and_retry = false;
+	bool           is_auto = arena_is_auto(arena);
 	cache_bin_sz_t filled = 0;
 	unsigned       binshard;
-	bin_t         *bin = arena_bin_choose(tsdn, arena, binind, &binshard);
+	bin_t         *bin = bin_choose(tsdn, arena, binind, &binshard);
 
 label_refill:
 	malloc_mutex_lock(tsdn, &bin->lock);
@@ -1109,22 +924,22 @@ label_refill:
 				cnt = nfill_min - filled;
 			}
 
-			arena_slab_reg_alloc_batch(
+			bin_slab_reg_alloc_batch(
 			    slabcur, bin_info, cnt, &arr->ptr[filled]);
 			made_progress = true;
 			filled += cnt;
 			continue;
 		}
 		/* Next try refilling slabcur from nonfull slabs. */
-		if (!arena_bin_refill_slabcur_no_fresh_slab(tsdn, arena, bin)) {
+		if (!bin_refill_slabcur_no_fresh_slab(tsdn, is_auto, bin)) {
 			assert(bin->slabcur != NULL);
 			continue;
 		}
 
 		/* Then see if a new slab was reserved already. */
 		if (fresh_slab != NULL) {
-			arena_bin_refill_slabcur_with_fresh_slab(
-			    tsdn, arena, bin, binind, fresh_slab);
+			bin_refill_slabcur_with_fresh_slab(
+			    tsdn, bin, binind, fresh_slab);
 			assert(bin->slabcur != NULL);
 			fresh_slab = NULL;
 			continue;
@@ -1193,7 +1008,7 @@ arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 
 	const bool manual_arena = !arena_is_auto(arena);
 	unsigned   binshard;
-	bin_t     *bin = arena_bin_choose(tsdn, arena, binind, &binshard);
+	bin_t     *bin = bin_choose(tsdn, arena, binind, &binshard);
 
 	size_t              nslab = 0;
 	size_t              filled = 0;
@@ -1212,7 +1027,7 @@ arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 			batch = nregs;
 		}
 		assert(batch > 0);
-		arena_slab_reg_alloc_batch(
+		bin_slab_reg_alloc_batch(
 		    slab, bin_info, (unsigned)batch, &ptrs[filled]);
 		assert(edata_addr_get(slab) == ptrs[filled]);
 		if (zero) {
@@ -1233,7 +1048,7 @@ arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 	 * iff slab != NULL.
 	 */
 	if (slab != NULL) {
-		arena_bin_lower_slab(tsdn, arena, slab, bin);
+		bin_lower_slab(tsdn, !manual_arena, slab, bin);
 	}
 	if (manual_arena) {
 		edata_list_active_concat(&bin->slabs_full, &fulls);
@@ -1252,35 +1067,18 @@ arena_fill_small_fresh(tsdn_t *tsdn, arena_t *arena, szind_t binind,
 	return filled;
 }
 
-/*
- * Without allocating a new slab, try arena_slab_reg_alloc() and re-fill
- * bin->slabcur if necessary.
- */
-static void *
-arena_bin_malloc_no_fresh_slab(
-    tsdn_t *tsdn, arena_t *arena, bin_t *bin, szind_t binind) {
-	malloc_mutex_assert_owner(tsdn, &bin->lock);
-	if (bin->slabcur == NULL || edata_nfree_get(bin->slabcur) == 0) {
-		if (arena_bin_refill_slabcur_no_fresh_slab(tsdn, arena, bin)) {
-			return NULL;
-		}
-	}
-
-	assert(bin->slabcur != NULL && edata_nfree_get(bin->slabcur) > 0);
-	return arena_slab_reg_alloc(bin->slabcur, &bin_infos[binind]);
-}
-
 static void *
 arena_malloc_small(tsdn_t *tsdn, arena_t *arena, szind_t binind, bool zero) {
 	assert(binind < SC_NBINS);
 	const bin_info_t *bin_info = &bin_infos[binind];
 	size_t            usize = sz_index2size(binind);
+	bool              is_auto = arena_is_auto(arena);
 	unsigned          binshard;
-	bin_t *bin = arena_bin_choose(tsdn, arena, binind, &binshard);
+	bin_t *bin = bin_choose(tsdn, arena, binind, &binshard);
 
 	malloc_mutex_lock(tsdn, &bin->lock);
 	edata_t *fresh_slab = NULL;
-	void    *ret = arena_bin_malloc_no_fresh_slab(tsdn, arena, bin, binind);
+	void    *ret = bin_malloc_no_fresh_slab(tsdn, is_auto, bin, binind);
 	if (ret == NULL) {
 		malloc_mutex_unlock(tsdn, &bin->lock);
 		/******************************/
@@ -1289,15 +1087,15 @@ arena_malloc_small(tsdn_t *tsdn, arena_t *arena, szind_t binind, bool zero) {
 		/********************************/
 		malloc_mutex_lock(tsdn, &bin->lock);
 		/* Retry since the lock was dropped. */
-		ret = arena_bin_malloc_no_fresh_slab(tsdn, arena, bin, binind);
+		ret = bin_malloc_no_fresh_slab(tsdn, is_auto, bin, binind);
 		if (ret == NULL) {
 			if (fresh_slab == NULL) {
 				/* OOM */
 				malloc_mutex_unlock(tsdn, &bin->lock);
 				return NULL;
 			}
-			ret = arena_bin_malloc_with_fresh_slab(
-			    tsdn, arena, bin, binind, fresh_slab);
+			ret = bin_malloc_with_fresh_slab(
+			    tsdn, bin, binind, fresh_slab);
 			fresh_slab = NULL;
 		}
 	}
@@ -1364,78 +1162,6 @@ arena_palloc(tsdn_t *tsdn, arena_t *arena, size_t usize, size_t alignment,
 			    tsdn, arena, usize, alignment, zero);
 		}
 	}
-}
-
-static void
-arena_dissociate_bin_slab(arena_t *arena, edata_t *slab, bin_t *bin) {
-	/* Dissociate slab from bin. */
-	if (slab == bin->slabcur) {
-		bin->slabcur = NULL;
-	} else {
-		szind_t           binind = edata_szind_get(slab);
-		const bin_info_t *bin_info = &bin_infos[binind];
-
-		/*
-		 * The following block's conditional is necessary because if the
-		 * slab only contains one region, then it never gets inserted
-		 * into the non-full slabs heap.
-		 */
-		if (bin_info->nregs == 1) {
-			arena_bin_slabs_full_remove(arena, bin, slab);
-		} else {
-			arena_bin_slabs_nonfull_remove(bin, slab);
-		}
-	}
-}
-
-static void
-arena_bin_lower_slab(tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin) {
-	assert(edata_nfree_get(slab) > 0);
-
-	/*
-	 * Make sure that if bin->slabcur is non-NULL, it refers to the
-	 * oldest/lowest non-full slab.  It is okay to NULL slabcur out rather
-	 * than proactively keeping it pointing at the oldest/lowest non-full
-	 * slab.
-	 */
-	if (bin->slabcur != NULL && edata_snad_comp(bin->slabcur, slab) > 0) {
-		/* Switch slabcur. */
-		if (edata_nfree_get(bin->slabcur) > 0) {
-			arena_bin_slabs_nonfull_insert(bin, bin->slabcur);
-		} else {
-			arena_bin_slabs_full_insert(arena, bin, bin->slabcur);
-		}
-		bin->slabcur = slab;
-		if (config_stats) {
-			bin->stats.reslabs++;
-		}
-	} else {
-		arena_bin_slabs_nonfull_insert(bin, slab);
-	}
-}
-
-static void
-arena_dalloc_bin_slab_prepare(tsdn_t *tsdn, edata_t *slab, bin_t *bin) {
-	malloc_mutex_assert_owner(tsdn, &bin->lock);
-
-	assert(slab != bin->slabcur);
-	if (config_stats) {
-		bin->stats.curslabs--;
-	}
-}
-
-void
-arena_dalloc_bin_locked_handle_newly_empty(
-    tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin) {
-	arena_dissociate_bin_slab(arena, slab, bin);
-	arena_dalloc_bin_slab_prepare(tsdn, slab, bin);
-}
-
-void
-arena_dalloc_bin_locked_handle_newly_nonempty(
-    tsdn_t *tsdn, arena_t *arena, edata_t *slab, bin_t *bin) {
-	arena_bin_slabs_full_remove(arena, bin, slab);
-	arena_bin_lower_slab(tsdn, arena, slab, bin);
 }
 
 static void
@@ -1637,7 +1363,7 @@ arena_ptr_array_flush_impl_small(tsdn_t *tsdn, szind_t binind,
 		 * thread's arena, so the stats didn't get merged.
 		 * Manually do so now.
 		 */
-		bin_t *bin = arena_bin_choose(tsdn, stats_arena, binind, NULL);
+		bin_t *bin = bin_choose(tsdn, stats_arena, binind, NULL);
 		malloc_mutex_lock(tsdn, &bin->lock);
 		bin->stats.nflushes++;
 		bin->stats.nrequests += (*merge_stats)->nrequests;

--- a/src/arena.c
+++ b/src/arena.c
@@ -1171,11 +1171,11 @@ arena_dalloc_bin(tsdn_t *tsdn, arena_t *arena, edata_t *edata, void *ptr) {
 	bin_t   *bin = arena_get_bin(arena, binind, binshard);
 
 	malloc_mutex_lock(tsdn, &bin->lock);
-	arena_dalloc_bin_locked_info_t info;
-	arena_dalloc_bin_locked_begin(&info, binind);
-	bool ret = arena_dalloc_bin_locked_step(
-	    tsdn, arena, bin, &info, binind, edata, ptr);
-	arena_dalloc_bin_locked_finish(tsdn, arena, bin, &info);
+	bin_dalloc_locked_info_t info;
+	bin_dalloc_locked_begin(&info, binind);
+	bool ret = bin_dalloc_locked_step(
+	    tsdn, arena_is_auto(arena), bin, &info, binind, edata, ptr);
+	bin_dalloc_locked_finish(tsdn, bin, &info);
 	malloc_mutex_unlock(tsdn, &bin->lock);
 
 	if (ret) {
@@ -1330,12 +1330,13 @@ arena_ptr_array_flush_impl_small(tsdn_t *tsdn, szind_t binind,
 
 		/* Next flush objects. */
 		/* Init only to avoid used-uninitialized warning. */
-		arena_dalloc_bin_locked_info_t dalloc_bin_info = {0};
-		arena_dalloc_bin_locked_begin(&dalloc_bin_info, binind);
+		bin_dalloc_locked_info_t dalloc_bin_info = {0};
+		bin_dalloc_locked_begin(&dalloc_bin_info, binind);
 		for (unsigned i = prev_flush_start; i < flush_start; i++) {
 			void    *ptr = arr->ptr[i];
 			edata_t *edata = item_edata[i].edata;
-			if (arena_dalloc_bin_locked_step(tsdn, cur_arena,
+			if (bin_dalloc_locked_step(tsdn,
+			        arena_is_auto(cur_arena),
 			        cur_bin, &dalloc_bin_info, binind, edata,
 			        ptr)) {
 				dalloc_slabs[dalloc_count] = edata;
@@ -1343,8 +1344,8 @@ arena_ptr_array_flush_impl_small(tsdn_t *tsdn, szind_t binind,
 			}
 		}
 
-		arena_dalloc_bin_locked_finish(
-		    tsdn, cur_arena, cur_bin, &dalloc_bin_info);
+		bin_dalloc_locked_finish(
+		    tsdn, cur_bin, &dalloc_bin_info);
 		malloc_mutex_unlock(tsdn, &cur_bin->lock);
 
 		arena_decay_ticks(

--- a/src/bin.c
+++ b/src/bin.c
@@ -67,3 +67,266 @@ void
 bin_postfork_child(tsdn_t *tsdn, bin_t *bin) {
 	malloc_mutex_postfork_child(tsdn, &bin->lock);
 }
+
+void *
+bin_slab_reg_alloc(edata_t *slab, const bin_info_t *bin_info) {
+	void        *ret;
+	slab_data_t *slab_data = edata_slab_data_get(slab);
+	size_t       regind;
+
+	assert(edata_nfree_get(slab) > 0);
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+
+	regind = bitmap_sfu(slab_data->bitmap, &bin_info->bitmap_info);
+	ret = (void *)((byte_t *)edata_addr_get(slab)
+	    + (uintptr_t)(bin_info->reg_size * regind));
+	edata_nfree_dec(slab);
+	return ret;
+}
+
+void
+bin_slab_reg_alloc_batch(
+    edata_t *slab, const bin_info_t *bin_info, unsigned cnt, void **ptrs) {
+	slab_data_t *slab_data = edata_slab_data_get(slab);
+
+	assert(edata_nfree_get(slab) >= cnt);
+	assert(!bitmap_full(slab_data->bitmap, &bin_info->bitmap_info));
+
+#if (!defined JEMALLOC_INTERNAL_POPCOUNTL) || (defined BITMAP_USE_TREE)
+	for (unsigned i = 0; i < cnt; i++) {
+		size_t regind = bitmap_sfu(
+		    slab_data->bitmap, &bin_info->bitmap_info);
+		*(ptrs + i) = (void *)((uintptr_t)edata_addr_get(slab)
+		    + (uintptr_t)(bin_info->reg_size * regind));
+	}
+#else
+	unsigned group = 0;
+	bitmap_t g = slab_data->bitmap[group];
+	unsigned i = 0;
+	while (i < cnt) {
+		while (g == 0) {
+			g = slab_data->bitmap[++group];
+		}
+		size_t shift = group << LG_BITMAP_GROUP_NBITS;
+		size_t pop = popcount_lu(g);
+		if (pop > (cnt - i)) {
+			pop = cnt - i;
+		}
+
+		/*
+		 * Load from memory locations only once, outside the
+		 * hot loop below.
+		 */
+		uintptr_t base = (uintptr_t)edata_addr_get(slab);
+		uintptr_t regsize = (uintptr_t)bin_info->reg_size;
+		while (pop--) {
+			size_t bit = cfs_lu(&g);
+			size_t regind = shift + bit;
+			/* NOLINTNEXTLINE(performance-no-int-to-ptr) */
+			*(ptrs + i) = (void *)(base + regsize * regind);
+
+			i++;
+		}
+		slab_data->bitmap[group] = g;
+	}
+#endif
+	edata_nfree_sub(slab, cnt);
+}
+
+void
+bin_slabs_nonfull_insert(bin_t *bin, edata_t *slab) {
+	assert(edata_nfree_get(slab) > 0);
+	edata_heap_insert(&bin->slabs_nonfull, slab);
+	if (config_stats) {
+		bin->stats.nonfull_slabs++;
+	}
+}
+
+void
+bin_slabs_nonfull_remove(bin_t *bin, edata_t *slab) {
+	edata_heap_remove(&bin->slabs_nonfull, slab);
+	if (config_stats) {
+		bin->stats.nonfull_slabs--;
+	}
+}
+
+edata_t *
+bin_slabs_nonfull_tryget(bin_t *bin) {
+	edata_t *slab = edata_heap_remove_first(&bin->slabs_nonfull);
+	if (slab == NULL) {
+		return NULL;
+	}
+	if (config_stats) {
+		bin->stats.reslabs++;
+		bin->stats.nonfull_slabs--;
+	}
+	return slab;
+}
+
+void
+bin_slabs_full_insert(bool is_auto, bin_t *bin, edata_t *slab) {
+	assert(edata_nfree_get(slab) == 0);
+	/*
+	 *  Tracking extents is required by arena_reset, which is not allowed
+	 *  for auto arenas.  Bypass this step to avoid touching the edata
+	 *  linkage (often results in cache misses) for auto arenas.
+	 */
+	if (is_auto) {
+		return;
+	}
+	edata_list_active_append(&bin->slabs_full, slab);
+}
+
+void
+bin_slabs_full_remove(bool is_auto, bin_t *bin, edata_t *slab) {
+	if (is_auto) {
+		return;
+	}
+	edata_list_active_remove(&bin->slabs_full, slab);
+}
+
+void
+bin_dissociate_slab(bool is_auto, edata_t *slab, bin_t *bin) {
+	/* Dissociate slab from bin. */
+	if (slab == bin->slabcur) {
+		bin->slabcur = NULL;
+	} else {
+		szind_t           binind = edata_szind_get(slab);
+		const bin_info_t *bin_info = &bin_infos[binind];
+
+		/*
+		 * The following block's conditional is necessary because if the
+		 * slab only contains one region, then it never gets inserted
+		 * into the non-full slabs heap.
+		 */
+		if (bin_info->nregs == 1) {
+			bin_slabs_full_remove(is_auto, bin, slab);
+		} else {
+			bin_slabs_nonfull_remove(bin, slab);
+		}
+	}
+}
+
+void
+bin_lower_slab(tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin) {
+	assert(edata_nfree_get(slab) > 0);
+
+	/*
+	 * Make sure that if bin->slabcur is non-NULL, it refers to the
+	 * oldest/lowest non-full slab.  It is okay to NULL slabcur out rather
+	 * than proactively keeping it pointing at the oldest/lowest non-full
+	 * slab.
+	 */
+	if (bin->slabcur != NULL && edata_snad_comp(bin->slabcur, slab) > 0) {
+		/* Switch slabcur. */
+		if (edata_nfree_get(bin->slabcur) > 0) {
+			bin_slabs_nonfull_insert(bin, bin->slabcur);
+		} else {
+			bin_slabs_full_insert(is_auto, bin, bin->slabcur);
+		}
+		bin->slabcur = slab;
+		if (config_stats) {
+			bin->stats.reslabs++;
+		}
+	} else {
+		bin_slabs_nonfull_insert(bin, slab);
+	}
+}
+
+void
+bin_dalloc_slab_prepare(tsdn_t *tsdn, edata_t *slab, bin_t *bin) {
+	malloc_mutex_assert_owner(tsdn, &bin->lock);
+
+	assert(slab != bin->slabcur);
+	if (config_stats) {
+		bin->stats.curslabs--;
+	}
+}
+
+void
+bin_dalloc_locked_handle_newly_empty(
+    tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin) {
+	bin_dissociate_slab(is_auto, slab, bin);
+	bin_dalloc_slab_prepare(tsdn, slab, bin);
+}
+
+void
+bin_dalloc_locked_handle_newly_nonempty(
+    tsdn_t *tsdn, bool is_auto, edata_t *slab, bin_t *bin) {
+	bin_slabs_full_remove(is_auto, bin, slab);
+	bin_lower_slab(tsdn, is_auto, slab, bin);
+}
+
+void
+bin_refill_slabcur_with_fresh_slab(tsdn_t *tsdn, bin_t *bin,
+    szind_t binind, edata_t *fresh_slab) {
+	malloc_mutex_assert_owner(tsdn, &bin->lock);
+	/* Only called after slabcur and nonfull both failed. */
+	assert(bin->slabcur == NULL);
+	assert(edata_heap_first(&bin->slabs_nonfull) == NULL);
+	assert(fresh_slab != NULL);
+
+	/* A new slab from arena_slab_alloc() */
+	assert(edata_nfree_get(fresh_slab) == bin_infos[binind].nregs);
+	if (config_stats) {
+		bin->stats.nslabs++;
+		bin->stats.curslabs++;
+	}
+	bin->slabcur = fresh_slab;
+}
+
+void *
+bin_malloc_with_fresh_slab(tsdn_t *tsdn, bin_t *bin,
+    szind_t binind, edata_t *fresh_slab) {
+	malloc_mutex_assert_owner(tsdn, &bin->lock);
+	bin_refill_slabcur_with_fresh_slab(tsdn, bin, binind, fresh_slab);
+
+	return bin_slab_reg_alloc(bin->slabcur, &bin_infos[binind]);
+}
+
+bool
+bin_refill_slabcur_no_fresh_slab(tsdn_t *tsdn, bool is_auto, bin_t *bin) {
+	malloc_mutex_assert_owner(tsdn, &bin->lock);
+	/* Only called after bin_slab_reg_alloc[_batch] failed. */
+	assert(bin->slabcur == NULL || edata_nfree_get(bin->slabcur) == 0);
+
+	if (bin->slabcur != NULL) {
+		bin_slabs_full_insert(is_auto, bin, bin->slabcur);
+	}
+
+	/* Look for a usable slab. */
+	bin->slabcur = bin_slabs_nonfull_tryget(bin);
+	assert(bin->slabcur == NULL || edata_nfree_get(bin->slabcur) > 0);
+
+	return (bin->slabcur == NULL);
+}
+
+void *
+bin_malloc_no_fresh_slab(tsdn_t *tsdn, bool is_auto, bin_t *bin,
+    szind_t binind) {
+	malloc_mutex_assert_owner(tsdn, &bin->lock);
+	if (bin->slabcur == NULL || edata_nfree_get(bin->slabcur) == 0) {
+		if (bin_refill_slabcur_no_fresh_slab(tsdn, is_auto, bin)) {
+			return NULL;
+		}
+	}
+
+	assert(bin->slabcur != NULL && edata_nfree_get(bin->slabcur) > 0);
+	return bin_slab_reg_alloc(bin->slabcur, &bin_infos[binind]);
+}
+
+bin_t *
+bin_choose(tsdn_t *tsdn, arena_t *arena, szind_t binind,
+    unsigned *binshard_p) {
+	unsigned binshard;
+	if (tsdn_null(tsdn) || tsd_arena_get(tsdn_tsd(tsdn)) == NULL) {
+		binshard = 0;
+	} else {
+		binshard = tsd_binshardsp_get(tsdn_tsd(tsdn))->binshard[binind];
+	}
+	assert(binshard < bin_infos[binind].n_shards);
+	if (binshard_p != NULL) {
+		*binshard_p = binshard;
+	}
+	return arena_get_bin(arena, binind, binshard);
+}

--- a/src/large.c
+++ b/src/large.c
@@ -41,7 +41,7 @@ large_palloc(
 		return NULL;
 	}
 
-	/* See comments in arena_bin_slabs_full_insert(). */
+	/* See comments in bin_slabs_full_insert(). */
 	if (!arena_is_auto(arena)) {
 		/* Insert edata into large. */
 		malloc_mutex_lock(tsdn, &arena->large_mtx);
@@ -233,7 +233,7 @@ static void
 large_dalloc_prep_impl(
     tsdn_t *tsdn, arena_t *arena, edata_t *edata, bool locked) {
 	if (!locked) {
-		/* See comments in arena_bin_slabs_full_insert(). */
+		/* See comments in bin_slabs_full_insert(). */
 		if (!arena_is_auto(arena)) {
 			malloc_mutex_lock(tsdn, &arena->large_mtx);
 			edata_list_active_remove(&arena->large, edata);

--- a/src/tcache.c
+++ b/src/tcache.c
@@ -218,7 +218,7 @@ tcache_gc_small_heuristic_addr_get(
     tsd_t *tsd, tcache_slow_t *tcache_slow, szind_t szind) {
 	assert(szind < SC_NBINS);
 	tsdn_t *tsdn = tsd_tsdn(tsd);
-	bin_t  *bin = arena_bin_choose(tsdn, tcache_slow->arena, szind, NULL);
+	bin_t  *bin = bin_choose(tsdn, tcache_slow->arena, szind, NULL);
 	assert(bin != NULL);
 
 	malloc_mutex_lock(tsdn, &bin->lock);
@@ -1275,7 +1275,7 @@ tcache_stats_merge(tsdn_t *tsdn, tcache_t *tcache, arena_t *arena) {
 			continue;
 		}
 		if (i < SC_NBINS) {
-			bin_t *bin = arena_bin_choose(tsdn, arena, i, NULL);
+			bin_t *bin = bin_choose(tsdn, arena, i, NULL);
 			malloc_mutex_lock(tsdn, &bin->lock);
 			bin->stats.nrequests += cache_bin->tstats.nrequests;
 			malloc_mutex_unlock(tsdn, &bin->lock);

--- a/test/unit/bin.c
+++ b/test/unit/bin.c
@@ -1,0 +1,825 @@
+#include "test/jemalloc_test.h"
+
+#define INVALID_ARENA_IND ((1U << MALLOCX_ARENA_BITS) - 1)
+
+/* Create a page-aligned mock slab with all regions free. */
+static void
+create_mock_slab(edata_t *slab, szind_t binind, uint64_t sn) {
+	const bin_info_t *bin_info = &bin_infos[binind];
+	void *addr;
+	slab_data_t *slab_data;
+
+	addr = mallocx(bin_info->slab_size, MALLOCX_LG_ALIGN(LG_PAGE));
+	assert_ptr_not_null(addr, "Unexpected mallocx failure");
+
+	memset(slab, 0, sizeof(edata_t));
+	edata_init(slab, INVALID_ARENA_IND, addr, bin_info->slab_size,
+	    true, binind, sn, extent_state_active, false, true,
+	    EXTENT_PAI_PAC, EXTENT_NOT_HEAD);
+	edata_nfree_set(slab, bin_info->nregs);
+
+	/* Initialize bitmap to all regions free. */
+	slab_data = edata_slab_data_get(slab);
+	bitmap_init(slab_data->bitmap, &bin_info->bitmap_info, false);
+}
+
+/*
+ * Test that bin_init produces a valid empty bin.
+ */
+TEST_BEGIN(test_bin_init) {
+	bin_t bin;
+	bool err;
+
+	err = bin_init(&bin);
+	expect_false(err, "bin_init should succeed");
+	expect_ptr_null(bin.slabcur, "New bin should have NULL slabcur");
+	expect_ptr_null(edata_heap_first(&bin.slabs_nonfull),
+	    "New bin should have empty nonfull heap");
+	expect_true(edata_list_active_empty(&bin.slabs_full),
+	    "New bin should have empty full list");
+	if (config_stats) {
+		expect_u64_eq(bin.stats.nmalloc, 0,
+		    "New bin should have zero nmalloc");
+		expect_u64_eq(bin.stats.ndalloc, 0,
+		    "New bin should have zero ndalloc");
+		expect_zu_eq(bin.stats.curregs, 0,
+		    "New bin should have zero curregs");
+		expect_zu_eq(bin.stats.curslabs, 0,
+		    "New bin should have zero curslabs");
+	}
+}
+TEST_END
+
+/*
+ * Test single-region allocation from a slab.
+ */
+TEST_BEGIN(test_bin_slab_reg_alloc) {
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned nregs;
+	unsigned i;
+
+	create_mock_slab(&slab, binind, 0);
+	nregs = bin_info->nregs;
+
+	for (i = 0; i < nregs; i++) {
+		void *reg;
+
+		expect_u_gt(edata_nfree_get(&slab), 0,
+		    "Slab should have free regions");
+		reg = bin_slab_reg_alloc(&slab, bin_info);
+		expect_ptr_not_null(reg,
+		    "bin_slab_reg_alloc should return non-NULL");
+		/* Verify the pointer is within the slab. */
+		expect_true(
+		    (uintptr_t)reg >= (uintptr_t)edata_addr_get(&slab) &&
+		    (uintptr_t)reg < (uintptr_t)edata_addr_get(&slab)
+		    + bin_info->slab_size,
+		    "Allocated region should be within slab bounds");
+	}
+	expect_u_eq(edata_nfree_get(&slab), 0,
+	    "Slab should be full after allocating all regions");
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test batch allocation from a slab.
+ */
+TEST_BEGIN(test_bin_slab_reg_alloc_batch) {
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned nregs;
+	void **ptrs;
+	unsigned i;
+
+	create_mock_slab(&slab, binind, 0);
+	nregs = bin_info->nregs;
+	ptrs = mallocx(nregs * sizeof(void *), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+
+	bin_slab_reg_alloc_batch(&slab, bin_info, nregs, ptrs);
+	expect_u_eq(edata_nfree_get(&slab), 0,
+	    "Slab should be full after batch alloc of all regions");
+
+	/* Verify all pointers are within the slab and distinct. */
+	for (i = 0; i < nregs; i++) {
+		unsigned j;
+
+		expect_ptr_not_null(ptrs[i], "Batch pointer should be non-NULL");
+		expect_true(
+		    (uintptr_t)ptrs[i] >= (uintptr_t)edata_addr_get(&slab) &&
+		    (uintptr_t)ptrs[i] < (uintptr_t)edata_addr_get(&slab)
+		    + bin_info->slab_size,
+		    "Batch pointer should be within slab bounds");
+		for (j = 0; j < i; j++) {
+			expect_ptr_ne(ptrs[i], ptrs[j],
+			    "Batch pointers should be distinct");
+		}
+	}
+	free(ptrs);
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test partial batch allocation from a slab.
+ */
+TEST_BEGIN(test_bin_slab_reg_alloc_batch_partial) {
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned nregs;
+	unsigned half;
+	void **ptrs;
+
+	create_mock_slab(&slab, binind, 0);
+	nregs = bin_info->nregs;
+
+	/* Only allocate half. */
+	half = nregs / 2;
+	if (half == 0) {
+		half = 1;
+	}
+	ptrs = mallocx(half * sizeof(void *), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+
+	bin_slab_reg_alloc_batch(&slab, bin_info, half, ptrs);
+	expect_u_eq(edata_nfree_get(&slab), nregs - half,
+	    "Slab nfree should reflect partial batch alloc");
+
+	free(ptrs);
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test nonfull slab list insert, remove, and tryget.
+ */
+TEST_BEGIN(test_bin_slabs_nonfull) {
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab1, slab2;
+	edata_t *got;
+	edata_t *remaining;
+
+	bin_init(&bin);
+
+	/* Create two non-full slabs with different serial numbers. */
+	create_mock_slab(&slab1, binind, 1);
+	create_mock_slab(&slab2, binind, 2);
+
+	/* Insert both into the nonfull heap. */
+	bin_slabs_nonfull_insert(&bin, &slab1);
+	expect_ptr_not_null(edata_heap_first(&bin.slabs_nonfull),
+	    "Nonfull heap should be non-empty after insert");
+
+	bin_slabs_nonfull_insert(&bin, &slab2);
+
+	/* tryget should return a slab. */
+	got = bin_slabs_nonfull_tryget(&bin);
+	expect_ptr_not_null(got, "tryget should return a slab");
+
+	/* Remove the remaining one explicitly. */
+	remaining = edata_heap_first(&bin.slabs_nonfull);
+	expect_ptr_not_null(remaining, "One slab should still remain");
+	bin_slabs_nonfull_remove(&bin, remaining);
+	expect_ptr_null(edata_heap_first(&bin.slabs_nonfull),
+	    "Nonfull heap should be empty after removing both slabs");
+
+	free(edata_addr_get(&slab1));
+	free(edata_addr_get(&slab2));
+}
+TEST_END
+
+/*
+ * Test full slab list insert and remove (non-auto arena case).
+ */
+TEST_BEGIN(test_bin_slabs_full) {
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned i;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	/* Consume all regions so the slab appears full. */
+	for (i = 0; i < bin_info->nregs; i++) {
+		bin_slab_reg_alloc(&slab, bin_info);
+	}
+	expect_u_eq(edata_nfree_get(&slab), 0, "Slab should be full");
+
+	/* Insert into full list (is_auto=false to actually track). */
+	bin_slabs_full_insert(false, &bin, &slab);
+	expect_false(edata_list_active_empty(&bin.slabs_full),
+	    "Full list should be non-empty after insert");
+
+	/* Remove from full list. */
+	bin_slabs_full_remove(false, &bin, &slab);
+	expect_true(edata_list_active_empty(&bin.slabs_full),
+	    "Full list should be empty after remove");
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test that full slab insert/remove is a no-op for auto arenas.
+ */
+TEST_BEGIN(test_bin_slabs_full_auto) {
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned i;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+	for (i = 0; i < bin_info->nregs; i++) {
+		bin_slab_reg_alloc(&slab, bin_info);
+	}
+
+	/* is_auto=true: insert should be a no-op. */
+	bin_slabs_full_insert(true, &bin, &slab);
+	expect_true(edata_list_active_empty(&bin.slabs_full),
+	    "Full list should remain empty for auto arenas");
+
+	/* Remove should also be a no-op without crashing. */
+	bin_slabs_full_remove(true, &bin, &slab);
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test dissociate_slab when the slab is slabcur.
+ */
+TEST_BEGIN(test_bin_dissociate_slabcur) {
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	bin.slabcur = &slab;
+	bin_dissociate_slab(true, &slab, &bin);
+	expect_ptr_null(bin.slabcur,
+	    "Dissociating slabcur should NULL it out");
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test dissociate_slab when the slab is in the nonfull heap.
+ */
+TEST_BEGIN(test_bin_dissociate_nonfull) {
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	/*
+	 * Only dissociate from nonfull when nregs > 1.  For nregs == 1,
+	 * the slab goes directly to the full list, never nonfull.
+	 */
+	test_skip_if(bin_info->nregs == 1);
+
+	bin_slabs_nonfull_insert(&bin, &slab);
+	bin_dissociate_slab(true, &slab, &bin);
+	expect_ptr_null(edata_heap_first(&bin.slabs_nonfull),
+	    "Nonfull heap should be empty after dissociating the slab");
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test refill slabcur with a fresh slab.
+ */
+TEST_BEGIN(test_bin_refill_slabcur_with_fresh_slab) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t fresh;
+
+	bin_init(&bin);
+	create_mock_slab(&fresh, binind, 0);
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+	bin_refill_slabcur_with_fresh_slab(tsdn, &bin, binind, &fresh);
+	expect_ptr_eq(bin.slabcur, &fresh,
+	    "Fresh slab should become slabcur");
+	if (config_stats) {
+		expect_u64_eq(bin.stats.nslabs, 1,
+		    "nslabs should be 1 after installing fresh slab");
+		expect_zu_eq(bin.stats.curslabs, 1,
+		    "curslabs should be 1 after installing fresh slab");
+	}
+	expect_u_eq(edata_nfree_get(bin.slabcur), bin_info->nregs,
+	    "Fresh slab should have all regions free");
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&fresh));
+}
+TEST_END
+
+/*
+ * Test refill slabcur without a fresh slab (from the nonfull heap).
+ */
+TEST_BEGIN(test_bin_refill_slabcur_no_fresh_slab) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab;
+	bool empty;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+
+	/* With no slabcur and empty nonfull heap, refill should fail. */
+	empty = bin_refill_slabcur_no_fresh_slab(tsdn, true, &bin);
+	expect_true(empty,
+	    "Refill should fail when nonfull heap is empty");
+	expect_ptr_null(bin.slabcur, "slabcur should remain NULL");
+
+	/* Insert a slab into nonfull, then refill should succeed. */
+	bin_slabs_nonfull_insert(&bin, &slab);
+	empty = bin_refill_slabcur_no_fresh_slab(tsdn, true, &bin);
+	expect_false(empty,
+	    "Refill should succeed when nonfull heap has a slab");
+	expect_ptr_eq(bin.slabcur, &slab,
+	    "slabcur should be the slab from nonfull heap");
+
+	malloc_mutex_unlock(tsdn, &bin.lock);
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test that refill moves a full slabcur into the full list.
+ */
+TEST_BEGIN(test_bin_refill_slabcur_full_to_list) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t full_slab, nonfull_slab;
+	unsigned i;
+	bool empty;
+
+	bin_init(&bin);
+	create_mock_slab(&full_slab, binind, 0);
+	create_mock_slab(&nonfull_slab, binind, 1);
+
+	/* Make full_slab actually full. */
+	for (i = 0; i < bin_info->nregs; i++) {
+		bin_slab_reg_alloc(&full_slab, bin_info);
+	}
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+	bin.slabcur = &full_slab;
+	bin_slabs_nonfull_insert(&bin, &nonfull_slab);
+
+	/* Refill should move the full slabcur to full list and pick nonfull. */
+	empty = bin_refill_slabcur_no_fresh_slab(tsdn, false, &bin);
+	expect_false(empty, "Refill should succeed");
+	expect_ptr_eq(bin.slabcur, &nonfull_slab,
+	    "slabcur should now be the nonfull slab");
+	expect_false(edata_list_active_empty(&bin.slabs_full),
+	    "Old full slabcur should be in the full list");
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&full_slab));
+	free(edata_addr_get(&nonfull_slab));
+}
+TEST_END
+
+/*
+ * Test malloc with a fresh slab.
+ */
+TEST_BEGIN(test_bin_malloc_with_fresh_slab) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t fresh;
+	void *ptr;
+
+	bin_init(&bin);
+	create_mock_slab(&fresh, binind, 0);
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+	ptr = bin_malloc_with_fresh_slab(tsdn, &bin, binind, &fresh);
+	expect_ptr_not_null(ptr, "Should allocate from fresh slab");
+	expect_ptr_eq(bin.slabcur, &fresh,
+	    "Fresh slab should be installed as slabcur");
+	expect_u_eq(edata_nfree_get(&fresh), bin_info->nregs - 1,
+	    "One region should be consumed from fresh slab");
+	if (config_stats) {
+		expect_u64_eq(bin.stats.nslabs, 1, "nslabs should be 1");
+		expect_zu_eq(bin.stats.curslabs, 1, "curslabs should be 1");
+	}
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&fresh));
+}
+TEST_END
+
+/*
+ * Test malloc without a fresh slab (from existing slabcur).
+ */
+TEST_BEGIN(test_bin_malloc_no_fresh_slab) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	void *ptr;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+
+	/* With no slabcur and empty nonfull, should return NULL. */
+	ptr = bin_malloc_no_fresh_slab(tsdn, true, &bin, binind);
+	expect_ptr_null(ptr,
+	    "Should return NULL when no slabs available");
+
+	/* Set up a slabcur; malloc should succeed. */
+	bin.slabcur = &slab;
+	ptr = bin_malloc_no_fresh_slab(tsdn, true, &bin, binind);
+	expect_ptr_not_null(ptr,
+	    "Should allocate from slabcur");
+	expect_u_eq(edata_nfree_get(&slab), bin_info->nregs - 1,
+	    "One region should be consumed");
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test the bin_dalloc_locked begin/step/finish sequence.
+ */
+TEST_BEGIN(test_bin_dalloc_locked) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	edata_t slab;
+	unsigned nregs;
+	void **ptrs;
+	unsigned i;
+	bin_dalloc_locked_info_t info;
+	bool slab_empty;
+	bool found_empty;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	/* Allocate all regions from the slab. */
+	nregs = bin_info->nregs;
+	ptrs = mallocx(nregs * sizeof(void *), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+	for (i = 0; i < nregs; i++) {
+		ptrs[i] = bin_slab_reg_alloc(&slab, bin_info);
+		assert_ptr_not_null(ptrs[i], "Alloc should succeed");
+	}
+	expect_u_eq(edata_nfree_get(&slab), 0, "Slab should be full");
+
+	/* Set this slab as slabcur so dalloc steps work correctly. */
+	bin.slabcur = &slab;
+	if (config_stats) {
+		bin.stats.nmalloc = nregs;
+		bin.stats.curregs = nregs;
+		bin.stats.nslabs = 1;
+		bin.stats.curslabs = 1;
+	}
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+
+	/* Free one region and verify step returns false (not yet empty). */
+	bin_dalloc_locked_begin(&info, binind);
+	slab_empty = bin_dalloc_locked_step(
+	    tsdn, true, &bin, &info, binind, &slab, ptrs[0]);
+	if (nregs > 1) {
+		expect_false(slab_empty,
+		    "Slab should not be empty after freeing one region");
+	}
+	bin_dalloc_locked_finish(tsdn, &bin, &info);
+	if (config_stats) {
+		expect_zu_eq(bin.stats.curregs, nregs - 1,
+		    "curregs should decrement by 1");
+	}
+
+	/* Free all remaining regions; the last one should empty the slab. */
+	bin_dalloc_locked_begin(&info, binind);
+	found_empty = false;
+	for (i = 1; i < nregs; i++) {
+		slab_empty = bin_dalloc_locked_step(
+		    tsdn, true, &bin, &info, binind, &slab, ptrs[i]);
+		if (slab_empty) {
+			found_empty = true;
+		}
+	}
+	bin_dalloc_locked_finish(tsdn, &bin, &info);
+	expect_true(found_empty,
+	    "Freeing all regions should produce an empty slab");
+	expect_u_eq(edata_nfree_get(&slab), nregs,
+	    "All regions should be free");
+	if (config_stats) {
+		expect_zu_eq(bin.stats.curregs, 0,
+		    "curregs should be 0 after freeing all");
+	}
+
+	malloc_mutex_unlock(tsdn, &bin.lock);
+	free(ptrs);
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test that bin_lower_slab replaces slabcur when the new slab is older.
+ */
+TEST_BEGIN(test_bin_lower_slab_replaces_slabcur) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab_old, slab_new;
+
+	bin_init(&bin);
+
+	/* slab_old has sn=0 (older), slab_new has sn=1 (newer). */
+	create_mock_slab(&slab_old, binind, 0);
+	create_mock_slab(&slab_new, binind, 1);
+
+	/* Make slab_new the slabcur. */
+	bin.slabcur = &slab_new;
+
+	/*
+	 * bin_lower_slab with the older slab should replace slabcur and move
+	 * slab_new into either nonfull or full.
+	 */
+	malloc_mutex_lock(tsdn, &bin.lock);
+	bin_lower_slab(tsdn, true, &slab_old, &bin);
+	expect_ptr_eq(bin.slabcur, &slab_old,
+	    "Older slab should replace slabcur");
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&slab_old));
+	free(edata_addr_get(&slab_new));
+}
+TEST_END
+
+/*
+ * Test that bin_lower_slab inserts into the nonfull heap when the new slab
+ * is newer than slabcur.
+ */
+TEST_BEGIN(test_bin_lower_slab_inserts_nonfull) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab_old, slab_new;
+
+	bin_init(&bin);
+	create_mock_slab(&slab_old, binind, 0);
+	create_mock_slab(&slab_new, binind, 1);
+
+	/* Make slab_old the slabcur (older). */
+	bin.slabcur = &slab_old;
+
+	/* bin_lower_slab with the newer slab should insert into nonfull. */
+	malloc_mutex_lock(tsdn, &bin.lock);
+	bin_lower_slab(tsdn, true, &slab_new, &bin);
+	expect_ptr_eq(bin.slabcur, &slab_old,
+	    "Older slabcur should remain");
+	expect_ptr_not_null(edata_heap_first(&bin.slabs_nonfull),
+	    "Newer slab should be inserted into nonfull heap");
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&slab_old));
+	free(edata_addr_get(&slab_new));
+}
+TEST_END
+
+/*
+ * Test bin_dalloc_slab_prepare updates stats.
+ */
+TEST_BEGIN(test_bin_dalloc_slab_prepare) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	edata_t slab;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	if (config_stats) {
+		bin.stats.curslabs = 2;
+	}
+
+	/*
+	 * bin_dalloc_slab_prepare requires the slab is not slabcur,
+	 * so leave slabcur NULL.
+	 */
+	malloc_mutex_lock(tsdn, &bin.lock);
+	bin_dalloc_slab_prepare(tsdn, &slab, &bin);
+	if (config_stats) {
+		expect_zu_eq(bin.stats.curslabs, 1,
+		    "curslabs should decrement");
+	}
+	malloc_mutex_unlock(tsdn, &bin.lock);
+
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test bin_shard_sizes_boot and bin_update_shard_size.
+ */
+TEST_BEGIN(test_bin_shard_sizes) {
+	unsigned shard_sizes[SC_NBINS];
+	unsigned i;
+	bool err;
+	szind_t ind1, ind2;
+
+	/* Boot should set all to the default. */
+	bin_shard_sizes_boot(shard_sizes);
+	for (i = 0; i < SC_NBINS; i++) {
+		expect_u_eq(shard_sizes[i], N_BIN_SHARDS_DEFAULT,
+		    "Shard sizes should be default after boot");
+	}
+
+	/* Update with nshards=0 should fail (returns true). */
+	err = bin_update_shard_size(shard_sizes, 1, 1, 0);
+	expect_true(err, "nshards=0 should be an error");
+
+	/* Update with nshards > BIN_SHARDS_MAX should fail. */
+	err = bin_update_shard_size(shard_sizes, 1, 1, BIN_SHARDS_MAX + 1);
+	expect_true(err, "nshards > BIN_SHARDS_MAX should be an error");
+
+	/* Valid update: set a range to 4 shards. */
+	err = bin_update_shard_size(shard_sizes, 1, 128, 4);
+	expect_false(err, "Valid update should succeed");
+	/* Verify the range was updated. */
+	ind1 = sz_size2index_compute(1);
+	ind2 = sz_size2index_compute(128);
+	for (i = ind1; i <= ind2; i++) {
+		expect_u_eq(shard_sizes[i], 4,
+		    "Updated range should have nshards=4");
+	}
+
+	/* Update beyond SC_SMALL_MAXCLASS should be clamped, not fail. */
+	err = bin_update_shard_size(shard_sizes,
+	    SC_SMALL_MAXCLASS, SC_SMALL_MAXCLASS * 2, 2);
+	expect_false(err,
+	    "Update with end beyond SMALL_MAXCLASS should succeed");
+}
+TEST_END
+
+/*
+ * Test a full alloc-then-free cycle by allocating all regions from a bin
+ * via bin_malloc_with_fresh_slab, then freeing them all via the
+ * bin_dalloc_locked sequence.
+ */
+TEST_BEGIN(test_bin_alloc_free_cycle) {
+	tsdn_t *tsdn = tsdn_fetch();
+	bin_t bin;
+	szind_t binind = 0;
+	const bin_info_t *bin_info = &bin_infos[binind];
+	unsigned nregs = bin_info->nregs;
+	edata_t slab;
+	void **ptrs;
+	unsigned i;
+	bin_dalloc_locked_info_t info;
+
+	bin_init(&bin);
+	create_mock_slab(&slab, binind, 0);
+
+	ptrs = mallocx(nregs * sizeof(void *), 0);
+	assert_ptr_not_null(ptrs, "Unexpected mallocx failure");
+
+	malloc_mutex_lock(tsdn, &bin.lock);
+
+	/* Allocate the first pointer via fresh slab path. */
+	ptrs[0] = bin_malloc_with_fresh_slab(tsdn, &bin, binind, &slab);
+	expect_ptr_not_null(ptrs[0], "First alloc should succeed");
+
+	/* Allocate the rest from slabcur. */
+	for (i = 1; i < nregs; i++) {
+		ptrs[i] = bin_malloc_no_fresh_slab(tsdn, true, &bin, binind);
+		expect_ptr_not_null(ptrs[i], "Alloc should succeed");
+	}
+	if (config_stats) {
+		bin.stats.nmalloc += nregs;
+		bin.stats.curregs += nregs;
+	}
+
+	expect_u_eq(edata_nfree_get(&slab), 0, "Slab should be full");
+
+	/* Free all regions. */
+	bin_dalloc_locked_begin(&info, binind);
+	for (i = 0; i < nregs; i++) {
+		bin_dalloc_locked_step(
+		    tsdn, true, &bin, &info, binind, &slab, ptrs[i]);
+	}
+	bin_dalloc_locked_finish(tsdn, &bin, &info);
+
+	expect_u_eq(edata_nfree_get(&slab), nregs,
+	    "All regions should be free after full cycle");
+	if (config_stats) {
+		expect_zu_eq(bin.stats.curregs, 0,
+		    "curregs should be 0 after full cycle");
+	}
+
+	malloc_mutex_unlock(tsdn, &bin.lock);
+	free(ptrs);
+	free(edata_addr_get(&slab));
+}
+TEST_END
+
+/*
+ * Test alloc/free cycle across multiple bin size classes.
+ */
+TEST_BEGIN(test_bin_multi_size_class) {
+	tsdn_t *tsdn = tsdn_fetch();
+	szind_t test_indices[] = {0, SC_NBINS / 2, SC_NBINS - 1};
+	unsigned nindices = sizeof(test_indices) / sizeof(test_indices[0]);
+	unsigned t;
+
+	for (t = 0; t < nindices; t++) {
+		szind_t binind = test_indices[t];
+		const bin_info_t *bin_info = &bin_infos[binind];
+		bin_t bin;
+		edata_t slab;
+		void *ptr;
+		bin_dalloc_locked_info_t info;
+
+		bin_init(&bin);
+		create_mock_slab(&slab, binind, 0);
+
+		malloc_mutex_lock(tsdn, &bin.lock);
+		ptr = bin_malloc_with_fresh_slab(
+		    tsdn, &bin, binind, &slab);
+		expect_ptr_not_null(ptr,
+		    "Alloc should succeed for binind %u", binind);
+		expect_u_eq(edata_nfree_get(&slab), bin_info->nregs - 1,
+		    "nfree should be nregs-1 for binind %u", binind);
+
+		/* Free the allocated region. */
+		if (config_stats) {
+			bin.stats.nmalloc = 1;
+			bin.stats.curregs = 1;
+		}
+		bin_dalloc_locked_begin(&info, binind);
+		bin_dalloc_locked_step(
+		    tsdn, true, &bin, &info, binind, &slab, ptr);
+		bin_dalloc_locked_finish(tsdn, &bin, &info);
+
+		expect_u_eq(edata_nfree_get(&slab), bin_info->nregs,
+		    "All regions should be free for binind %u", binind);
+		malloc_mutex_unlock(tsdn, &bin.lock);
+
+		free(edata_addr_get(&slab));
+	}
+}
+TEST_END
+
+int
+main(void) {
+	return test(
+	    test_bin_init,
+	    test_bin_slab_reg_alloc,
+	    test_bin_slab_reg_alloc_batch,
+	    test_bin_slab_reg_alloc_batch_partial,
+	    test_bin_slabs_nonfull,
+	    test_bin_slabs_full,
+	    test_bin_slabs_full_auto,
+	    test_bin_dissociate_slabcur,
+	    test_bin_dissociate_nonfull,
+	    test_bin_refill_slabcur_with_fresh_slab,
+	    test_bin_refill_slabcur_no_fresh_slab,
+	    test_bin_refill_slabcur_full_to_list,
+	    test_bin_malloc_with_fresh_slab,
+	    test_bin_malloc_no_fresh_slab,
+	    test_bin_dalloc_locked,
+	    test_bin_lower_slab_replaces_slabcur,
+	    test_bin_lower_slab_inserts_nonfull,
+	    test_bin_dalloc_slab_prepare,
+	    test_bin_shard_sizes,
+	    test_bin_alloc_free_cycle,
+	    test_bin_multi_size_class);
+}

--- a/test/unit/slab.c
+++ b/test/unit/slab.c
@@ -2,7 +2,7 @@
 
 #define INVALID_ARENA_IND ((1U << MALLOCX_ARENA_BITS) - 1)
 
-TEST_BEGIN(test_arena_slab_regind) {
+TEST_BEGIN(test_bin_slab_regind) {
 	szind_t binind;
 
 	for (binind = 0; binind < SC_NBINS; binind++) {
@@ -15,13 +15,13 @@ TEST_BEGIN(test_arena_slab_regind) {
 		    false, true, EXTENT_PAI_PAC, EXTENT_NOT_HEAD);
 		expect_ptr_not_null(
 		    edata_addr_get(&slab), "Unexpected malloc() failure");
-		arena_dalloc_bin_locked_info_t dalloc_info;
-		arena_dalloc_bin_locked_begin(&dalloc_info, binind);
+		bin_dalloc_locked_info_t dalloc_info;
+		bin_dalloc_locked_begin(&dalloc_info, binind);
 		for (regind = 0; regind < bin_info->nregs; regind++) {
 			void *reg = (void *)((uintptr_t)edata_addr_get(&slab)
 			    + (bin_info->reg_size * regind));
 			expect_zu_eq(
-			    arena_slab_regind(&dalloc_info, binind, &slab, reg),
+			    bin_slab_regind(&dalloc_info, binind, &slab, reg),
 			    regind,
 			    "Incorrect region index computed for size %zu",
 			    bin_info->reg_size);
@@ -33,5 +33,5 @@ TEST_END
 
 int
 main(void) {
-	return test(test_arena_slab_regind);
+	return test(test_bin_slab_regind);
 }


### PR DESCRIPTION
This change moves the bin functions out of the arena code and into
their own source code file.  To distinguish them from arena functions,
they are now given the prefix `bin_` instead of `arena_`.  To further
decouple the code, instead of being passed an `arena_t *`, callers
have been changed to explicitly pass any `arena_t` member values the
bin functions might need.  Finally, unit test coverage has been added
for the bin interfaces.