### PR TITLE
Remove hpa_sec_batch_fill_extra and calculate nallocs dynamically.

### DIFF
--- a/include/jemalloc/internal/hpdata.h
+++ b/include/jemalloc/internal/hpdata.h
@@ -395,6 +395,25 @@ void hpdata_init(hpdata_t *hpdata, void *addr, uint64_t age, bool is_huge);
 void *hpdata_reserve_alloc(hpdata_t *hpdata, size_t sz);
 void  hpdata_unreserve(hpdata_t *hpdata, void *addr, size_t sz);
 
+typedef struct hpdata_alloc_offset_s hpdata_alloc_offset_t;
+struct hpdata_alloc_offset_s {
+	size_t index;
+	size_t len;
+};
+
+/*
+ * Given an hpdata which can serve an allocation request of size sz,
+ * find between one and max_nallocs offsets that can satisfy such
+ * an allocation request and buffer them in offsets (without actually
+ * reserving any space or updating hpdata). Return the number
+ * of offsets discovered.
+ */
+size_t hpdata_find_alloc_offsets(hpdata_t *hpdata, size_t sz,
+    hpdata_alloc_offset_t *offsets, size_t max_nallocs);
+/* Reserve the allocation for the given offset. */
+void *hpdata_reserve_alloc_offset(
+    hpdata_t *hpdata, size_t sz, hpdata_alloc_offset_t *offset);
+
 /*
  * The hpdata_purge_prepare_t allows grabbing the metadata required to purge
  * subranges of a hugepage while holding a lock, drop the lock during the actual

--- a/include/jemalloc/internal/sec.h
+++ b/include/jemalloc/internal/sec.h
@@ -96,6 +96,16 @@ sec_size_supported(sec_t *sec, size_t size) {
 	return sec_is_used(sec) && size <= sec->opts.max_alloc;
 }
 
+/* Max number of extends we would allocate out of a single huge page. */
+#define MAX_SEC_NALLOCS 4
+
+/*
+ * Calculate the number of extends we will try to allocate out of
+ * a single huge page for a given allocation size. The result will be
+ * in the range [1, MAX_SEC_NALLOCS].
+ */
+size_t sec_calc_nallocs_for_size(sec_t *sec, size_t size);
+
 /* If sec does not have extent available, it will return NULL. */
 edata_t *sec_alloc(tsdn_t *tsdn, sec_t *sec, size_t size);
 void     sec_fill(tsdn_t *tsdn, sec_t *sec, size_t size,

--- a/include/jemalloc/internal/sec_opts.h
+++ b/include/jemalloc/internal/sec_opts.h
@@ -27,16 +27,9 @@ struct sec_opts_s {
 	 * until we are 1/4 below max_bytes.
 	 */
 	size_t max_bytes;
-	/*
-	 * When we can't satisfy an allocation out of the SEC because there are
-	 * no available ones cached, allocator will allocate a batch with extra
-	 * batch_fill_extra extents of the same size.
-	 */
-	size_t batch_fill_extra;
 };
 
 #define SEC_OPTS_NSHARDS_DEFAULT 2
-#define SEC_OPTS_BATCH_FILL_EXTRA_DEFAULT 3
 #define SEC_OPTS_MAX_ALLOC_DEFAULT ((32 * 1024) < PAGE ? PAGE : (32 * 1024))
 #define SEC_OPTS_MAX_BYTES_DEFAULT                                             \
 	((256 * 1024) < (4 * SEC_OPTS_MAX_ALLOC_DEFAULT)                       \
@@ -45,6 +38,6 @@ struct sec_opts_s {
 
 #define SEC_OPTS_DEFAULT                                                       \
 	{SEC_OPTS_NSHARDS_DEFAULT, SEC_OPTS_MAX_ALLOC_DEFAULT,                 \
-	    SEC_OPTS_MAX_BYTES_DEFAULT, SEC_OPTS_BATCH_FILL_EXTRA_DEFAULT}
+	    SEC_OPTS_MAX_BYTES_DEFAULT}
 
 #endif /* JEMALLOC_INTERNAL_SEC_OPTS_H */

--- a/src/conf.c
+++ b/src/conf.c
@@ -254,9 +254,8 @@ JEMALLOC_DIAGNOSTIC_PUSH
 JEMALLOC_DIAGNOSTIC_IGNORE("-Wunused-function")
 
 JET_EXTERN bool
-conf_handle_unsigned(const char *v, size_t vlen,
-    uintmax_t min, uintmax_t max, bool check_min, bool check_max,
-    bool clip, uintmax_t *result) {
+conf_handle_unsigned(const char *v, size_t vlen, uintmax_t min, uintmax_t max,
+    bool check_min, bool check_max, bool clip, uintmax_t *result) {
 	char *end;
 	set_errno(0);
 	uintmax_t mv = (uintmax_t)malloc_strtoumax(v, &end, 0);
@@ -281,9 +280,8 @@ conf_handle_unsigned(const char *v, size_t vlen,
 }
 
 JET_EXTERN bool
-conf_handle_signed(const char *v, size_t vlen,
-    intmax_t min, intmax_t max, bool check_min, bool check_max,
-    bool clip, intmax_t *result) {
+conf_handle_signed(const char *v, size_t vlen, intmax_t min, intmax_t max,
+    bool check_min, bool check_max, bool clip, intmax_t *result) {
 	char *end;
 	set_errno(0);
 	intmax_t mv = (intmax_t)malloc_strtoumax(v, &end, 0);
@@ -473,11 +471,11 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			continue;
 		}
 
-		while (*opts != '\0'
-		    && !conf_next(&opts, &k, &klen, &v, &vlen)) {
+		while (
+		    *opts != '\0' && !conf_next(&opts, &k, &klen, &v, &vlen)) {
 #define CONF_ERROR(msg, k, klen, v, vlen)                                      \
 	if (!initial_call) {                                                   \
-		conf_error(msg, k, klen, v, vlen);                      \
+		conf_error(msg, k, klen, v, vlen);                             \
 		cur_opt_valid = false;                                         \
 	}
 #define CONF_CONTINUE                                                          \
@@ -977,9 +975,6 @@ malloc_conf_init_helper(sc_data_t *sc_data, unsigned bin_shard_sizes[SC_NBINS],
 			CONF_HANDLE_SIZE_T(opt_hpa_sec_opts.max_bytes,
 			    "hpa_sec_max_bytes", SEC_OPTS_MAX_BYTES_DEFAULT, 0,
 			    CONF_CHECK_MIN, CONF_DONT_CHECK_MAX, true);
-			CONF_HANDLE_SIZE_T(opt_hpa_sec_opts.batch_fill_extra,
-			    "hpa_sec_batch_fill_extra", 1, HUGEPAGE_PAGES,
-			    CONF_CHECK_MIN, CONF_CHECK_MAX, true);
 
 			if (CONF_MATCH("slab_sizes")) {
 				if (CONF_MATCH_VALUE("default")) {

--- a/src/ctl.c
+++ b/src/ctl.c
@@ -115,7 +115,6 @@ CTL_PROTO(opt_hpa_dirty_mult)
 CTL_PROTO(opt_hpa_sec_nshards)
 CTL_PROTO(opt_hpa_sec_max_alloc)
 CTL_PROTO(opt_hpa_sec_max_bytes)
-CTL_PROTO(opt_hpa_sec_batch_fill_extra)
 CTL_PROTO(opt_huge_arena_pac_thp)
 CTL_PROTO(opt_metadata_thp)
 CTL_PROTO(opt_retain)
@@ -488,7 +487,6 @@ static const ctl_named_node_t opt_node[] = {{NAME("abort"), CTL(opt_abort)},
     {NAME("hpa_sec_nshards"), CTL(opt_hpa_sec_nshards)},
     {NAME("hpa_sec_max_alloc"), CTL(opt_hpa_sec_max_alloc)},
     {NAME("hpa_sec_max_bytes"), CTL(opt_hpa_sec_max_bytes)},
-    {NAME("hpa_sec_batch_fill_extra"), CTL(opt_hpa_sec_batch_fill_extra)},
     {NAME("huge_arena_pac_thp"), CTL(opt_huge_arena_pac_thp)},
     {NAME("metadata_thp"), CTL(opt_metadata_thp)},
     {NAME("retain"), CTL(opt_retain)}, {NAME("dss"), CTL(opt_dss)},
@@ -2178,8 +2176,6 @@ CTL_RO_NL_GEN(opt_hpa_slab_max_alloc, opt_hpa_opts.slab_max_alloc, size_t)
 CTL_RO_NL_GEN(opt_hpa_sec_nshards, opt_hpa_sec_opts.nshards, size_t)
 CTL_RO_NL_GEN(opt_hpa_sec_max_alloc, opt_hpa_sec_opts.max_alloc, size_t)
 CTL_RO_NL_GEN(opt_hpa_sec_max_bytes, opt_hpa_sec_opts.max_bytes, size_t)
-CTL_RO_NL_GEN(
-    opt_hpa_sec_batch_fill_extra, opt_hpa_sec_opts.batch_fill_extra, size_t)
 CTL_RO_NL_GEN(opt_huge_arena_pac_thp, opt_huge_arena_pac_thp, bool)
 CTL_RO_NL_GEN(
     opt_metadata_thp, metadata_thp_mode_names[opt_metadata_thp], const char *)

--- a/src/hpa.c
+++ b/src/hpa.c
@@ -651,37 +651,18 @@ hpa_shard_maybe_do_deferred_work(
 }
 
 static edata_t *
-hpa_try_alloc_one_no_grow(
-    tsdn_t *tsdn, hpa_shard_t *shard, size_t size, bool *oom) {
+hpa_try_alloc_one_no_grow(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
+    hpdata_t *ps, hpdata_alloc_offset_t *alloc_offset, bool *oom) {
+	assert(*oom == false);
 	malloc_mutex_assert_owner(tsdn, &shard->mtx);
 
-	bool     err;
 	edata_t *edata = edata_cache_fast_get(tsdn, &shard->ecf);
 	if (edata == NULL) {
 		*oom = true;
 		return NULL;
 	}
 
-	hpdata_t *ps = psset_pick_alloc(&shard->psset, size);
-	if (ps == NULL) {
-		edata_cache_fast_put(tsdn, &shard->ecf, edata);
-		return NULL;
-	}
-
-	psset_update_begin(&shard->psset, ps);
-
-	if (hpdata_empty(ps)) {
-		/*
-		 * If the pageslab used to be empty, treat it as though it's
-		 * brand new for fragmentation-avoidance purposes; what we're
-		 * trying to approximate is the age of the allocations *in* that
-		 * pageslab, and the allocations in the new pageslab are by
-		 * definition the youngest in this hpa shard.
-		 */
-		hpdata_age_set(ps, shard->age_counter++);
-	}
-
-	void *addr = hpdata_reserve_alloc(ps, size);
+	void *addr = hpdata_reserve_alloc_offset(ps, size, alloc_offset);
 	JE_USDT(hpa_alloc, 5, shard->ind, addr, size, hpdata_nactive_get(ps),
 	    hpdata_age_get(ps));
 	edata_init(edata, shard->ind, addr, size, /* slab */ false, SC_NSIZES,
@@ -693,12 +674,12 @@ hpa_try_alloc_one_no_grow(
 	/*
 	 * This could theoretically be moved outside of the critical section,
 	 * but that introduces the potential for a race.  Without the lock, the
-	 * (initially nonempty, since this is the reuse pathway) pageslab we
+   	 * (initially nonempty, since this is the reuse pathway) pageslab we
 	 * allocated out of could become otherwise empty while the lock is
 	 * dropped.  This would force us to deal with a pageslab eviction down
 	 * the error pathway, which is a pain.
 	 */
-	err = emap_register_boundary(
+	const bool err = emap_register_boundary(
 	    tsdn, shard->emap, edata, SC_NSIZES, /* slab */ false);
 	if (err) {
 		hpdata_unreserve(
@@ -715,29 +696,61 @@ hpa_try_alloc_one_no_grow(
 		 * principle that we didn't *really* affect shard state (we
 		 * tweaked the stats, but our tweaks weren't really accurate).
 		 */
-		psset_update_end(&shard->psset, ps);
 		edata_cache_fast_put(tsdn, &shard->ecf, edata);
 		*oom = true;
 		return NULL;
 	}
 
 	hpa_update_purge_hugify_eligibility(tsdn, shard, ps);
-	psset_update_end(&shard->psset, ps);
+
 	return edata;
 }
 
 static size_t
 hpa_try_alloc_batch_no_grow_locked(tsdn_t *tsdn, hpa_shard_t *shard,
-    size_t size, bool *oom, size_t nallocs, edata_list_active_t *results,
+    size_t size, bool *oom, edata_list_active_t *results,
     bool *deferred_work_generated) {
+	assert(size <= HUGEPAGE);
+	assert(size <= shard->opts.slab_max_alloc || size == sz_s2u(size));
+	assert(*oom == false);
 	malloc_mutex_assert_owner(tsdn, &shard->mtx);
+
+	hpdata_t *ps = psset_pick_alloc(&shard->psset, size);
+	if (ps == NULL) {
+		return 0;
+	}
+
+	hpdata_alloc_offset_t alloc_offsets[MAX_SEC_NALLOCS];
+	const size_t max_nallocs = sec_calc_nallocs_for_size(&shard->sec, size);
+	const size_t nallocs = hpdata_find_alloc_offsets(
+	    ps, size, alloc_offsets, max_nallocs);
+
+	psset_update_begin(&shard->psset, ps);
+
+	if (hpdata_empty(ps)) {
+		/*
+ 		 * If the pageslab used to be empty, treat it as though it's
+		 * brand new for fragmentation-avoidance purposes; what we're
+		 * trying to approximate is the age of the allocations *in* that
+		 * pageslab, and the allocations in the new pageslab are by
+		 * definition the youngest in this hpa shard.
+		 */
+		hpdata_age_set(ps, shard->age_counter++);
+	}
+
+	psset_update_end(&shard->psset, ps);
+
 	size_t nsuccess = 0;
-	for (; nsuccess < nallocs; nsuccess++) {
+	for (; nsuccess < nallocs; nsuccess += 1) {
+		psset_update_begin(&shard->psset, ps);
 		edata_t *edata = hpa_try_alloc_one_no_grow(
-		    tsdn, shard, size, oom);
+		    tsdn, shard, size, ps, &alloc_offsets[nsuccess], oom);
+		psset_update_end(&shard->psset, ps);
+
 		if (edata == NULL) {
 			break;
 		}
+
 		edata_list_active_append(results, edata);
 	}
 
@@ -748,27 +761,22 @@ hpa_try_alloc_batch_no_grow_locked(tsdn_t *tsdn, hpa_shard_t *shard,
 
 static size_t
 hpa_try_alloc_batch_no_grow(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
-    bool *oom, size_t nallocs, edata_list_active_t *results,
-    bool *deferred_work_generated) {
+    bool *oom, edata_list_active_t *results, bool *deferred_work_generated) {
 	malloc_mutex_lock(tsdn, &shard->mtx);
-	size_t nsuccess = hpa_try_alloc_batch_no_grow_locked(
-	    tsdn, shard, size, oom, nallocs, results, deferred_work_generated);
+	const size_t nsuccess = hpa_try_alloc_batch_no_grow_locked(
+	    tsdn, shard, size, oom, results, deferred_work_generated);
 	malloc_mutex_unlock(tsdn, &shard->mtx);
 	return nsuccess;
 }
 
 static size_t
 hpa_alloc_batch_psset(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
-    size_t nallocs, edata_list_active_t *results,
-    bool *deferred_work_generated) {
-	assert(size <= HUGEPAGE);
-	assert(size <= shard->opts.slab_max_alloc || size == sz_s2u(size));
+    edata_list_active_t *results, bool *deferred_work_generated) {
 	bool oom = false;
 
 	size_t nsuccess = hpa_try_alloc_batch_no_grow(
-	    tsdn, shard, size, &oom, nallocs, results, deferred_work_generated);
-
-	if (nsuccess == nallocs || oom) {
+	    tsdn, shard, size, &oom, results, deferred_work_generated);
+	if (0 < nsuccess || oom) {
 		return nsuccess;
 	}
 
@@ -777,13 +785,14 @@ hpa_alloc_batch_psset(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
 	 * try to grow.
 	 */
 	malloc_mutex_lock(tsdn, &shard->grow_mtx);
+
 	/*
 	 * Check for grow races; maybe some earlier thread expanded the psset
 	 * in between when we dropped the main mutex and grabbed the grow mutex.
 	 */
-	nsuccess += hpa_try_alloc_batch_no_grow(tsdn, shard, size, &oom,
-	    nallocs - nsuccess, results, deferred_work_generated);
-	if (nsuccess == nallocs || oom) {
+	nsuccess = hpa_try_alloc_batch_no_grow(
+	    tsdn, shard, size, &oom, results, deferred_work_generated);
+	if (0 < nsuccess || oom) {
 		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
 		return nsuccess;
 	}
@@ -797,7 +806,7 @@ hpa_alloc_batch_psset(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
 	    shard->age_counter++, hpa_is_hugify_eager(shard), &oom);
 	if (ps == NULL) {
 		malloc_mutex_unlock(tsdn, &shard->grow_mtx);
-		return nsuccess;
+		return 0;
 	}
 
 	/*
@@ -807,14 +816,10 @@ hpa_alloc_batch_psset(tsdn_t *tsdn, hpa_shard_t *shard, size_t size,
 	 */
 	malloc_mutex_lock(tsdn, &shard->mtx);
 	psset_insert(&shard->psset, ps);
-	nsuccess += hpa_try_alloc_batch_no_grow_locked(tsdn, shard, size, &oom,
-	    nallocs - nsuccess, results, deferred_work_generated);
+	nsuccess = hpa_try_alloc_batch_no_grow_locked(
+	    tsdn, shard, size, &oom, results, deferred_work_generated);
 	malloc_mutex_unlock(tsdn, &shard->mtx);
 
-	/*
-	 * Drop grow_mtx before doing deferred work; other threads blocked on it
-	 * should be allowed to proceed while we're working.
-	 */
 	malloc_mutex_unlock(tsdn, &shard->grow_mtx);
 
 	return nsuccess;
@@ -886,13 +891,10 @@ hpa_alloc(tsdn_t *tsdn, pai_t *self, size_t size, size_t alignment, bool zero,
 	if (edata != NULL) {
 		return edata;
 	}
-	size_t              nallocs = sec_size_supported(&shard->sec, size)
-	                 ? shard->sec.opts.batch_fill_extra + 1
-	                 : 1;
 	edata_list_active_t results;
 	edata_list_active_init(&results);
 	size_t nsuccess = hpa_alloc_batch_psset(
-	    tsdn, shard, size, nallocs, &results, deferred_work_generated);
+	    tsdn, shard, size, &results, deferred_work_generated);
 	hpa_assert_results(tsdn, shard, &results);
 	edata = edata_list_active_first(&results);
 

--- a/src/hpdata.c
+++ b/src/hpdata.c
@@ -171,6 +171,108 @@ hpdata_unreserve(hpdata_t *hpdata, void *addr, size_t sz) {
 }
 
 size_t
+hpdata_find_alloc_offsets(hpdata_t *hpdata, size_t sz,
+    hpdata_alloc_offset_t *offsets, size_t max_nallocs) {
+	hpdata_assert_consistent(hpdata);
+	assert((sz & PAGE_MASK) == 0);
+	const size_t npages = sz >> LG_PAGE;
+	/* We should be able to find at least one allocation */
+	assert(npages <= hpdata_longest_free_range_get(hpdata));
+
+	bool   found = false;
+	size_t nallocs = 0;
+	size_t start = 0;
+	/*
+	 * These are dead stores, but the compiler will issue warnings on them
+	 * since it can't tell statically that found is always true below.
+	 */
+	size_t begin = 0;
+	size_t len = 0;
+
+	while (true) {
+		found = found
+		    || fb_urange_iter(hpdata->active_pages, HUGEPAGE_PAGES,
+		        start, &begin, &len);
+		if (!found) {
+			/* we should have found at least one */
+			assert(0 < nallocs);
+			break;
+		}
+
+		if (npages <= len) {
+			offsets->len = len;
+			offsets->index = begin;
+			offsets += 1;
+			nallocs += 1;
+
+			if (nallocs == max_nallocs) {
+				break;
+			}
+
+			begin += npages;
+			len -= npages;
+		} else {
+			found = false;
+			start = begin + len;
+			assert(start <= HUGEPAGE_PAGES);
+			if (start == HUGEPAGE_PAGES) {
+				break;
+			}
+		}
+	}
+
+	/* post-conditions */
+	assert(1 <= nallocs);
+	assert(nallocs <= max_nallocs);
+
+	return nallocs;
+}
+
+void *
+hpdata_reserve_alloc_offset(
+    hpdata_t *hpdata, size_t sz, hpdata_alloc_offset_t *offset) {
+	hpdata_assert_consistent(hpdata);
+
+	/*
+	 * This is a metadata change; the hpdata should therefore either not be
+	 * in the psset, or should have explicitly marked itself as being
+	 * mid-update.
+	 */
+	assert(!hpdata->h_in_psset || hpdata->h_updating);
+	assert(hpdata->h_alloc_allowed);
+	assert((sz & PAGE_MASK) == 0);
+	const size_t npages = sz >> LG_PAGE;
+	const size_t index = offset->index;
+
+	fb_set_range(hpdata->active_pages, HUGEPAGE_PAGES, index, npages);
+	hpdata->h_nactive += npages;
+
+	/*
+	 * We might be about to dirty some memory for the first time; update our
+	 * count if so.
+	 */
+	size_t new_dirty = fb_ucount(
+	    hpdata->touched_pages, HUGEPAGE_PAGES, index, npages);
+	fb_set_range(hpdata->touched_pages, HUGEPAGE_PAGES, index, npages);
+	hpdata->h_ntouched += new_dirty;
+
+	/*
+	 * If we allocated out of a range that was the longest in the hpdata, it
+	 * might be the only one of that size and we'll have to adjust the
+	 * metadata.
+	 */
+	assert(offset->len <= hpdata_longest_free_range_get(hpdata));
+	if (offset->len == hpdata_longest_free_range_get(hpdata)) {
+		const size_t longest_unchosen_range = fb_urange_longest(
+		    hpdata->active_pages, HUGEPAGE_PAGES);
+		hpdata_longest_free_range_set(hpdata, longest_unchosen_range);
+	}
+
+	hpdata_assert_consistent(hpdata);
+	return (void *)((byte_t *)hpdata_addr_get(hpdata) + (index << LG_PAGE));
+}
+
+size_t
 hpdata_purge_begin(
     hpdata_t *hpdata, hpdata_purge_state_t *purge_state, size_t *nranges) {
 	hpdata_assert_consistent(hpdata);

--- a/src/jemalloc.c
+++ b/src/jemalloc.c
@@ -161,13 +161,13 @@ void (*JET_MUTABLE junk_free_callback)(
     void *ptr, size_t size) = &default_junk_free;
 void (*JET_MUTABLE invalid_conf_abort)(void) = &abort;
 
-bool         opt_utrace = false;
-bool         opt_xmalloc = false;
-bool         opt_experimental_infallible_new = false;
-bool         opt_experimental_tcache_gc = true;
-bool         opt_zero = false;
-unsigned     opt_narenas = 0;
-fxp_t opt_narenas_ratio = FXP_INIT_INT(4);
+bool     opt_utrace = false;
+bool     opt_xmalloc = false;
+bool     opt_experimental_infallible_new = false;
+bool     opt_experimental_tcache_gc = true;
+bool     opt_zero = false;
+unsigned opt_narenas = 0;
+fxp_t    opt_narenas_ratio = FXP_INIT_INT(4);
 
 unsigned ncpus;
 
@@ -292,7 +292,6 @@ typedef struct {
 #else
 #	define UTRACE(a, b, c)
 #endif
-
 
 /******************************************************************************/
 /*

--- a/src/sec.c
+++ b/src/sec.c
@@ -90,6 +90,33 @@ sec_bin_pick(sec_t *sec, uint8_t shard, pszind_t pszind) {
 	return &sec->bins[ind];
 }
 
+#define MAX_BYTES_DIV 8
+
+size_t
+sec_calc_nallocs_for_size(sec_t *sec, size_t size) {
+	size_t res = 1;
+
+	if (sec_size_supported(sec, size)) {
+		/*
+		 * This attempts to fill up up to 1/8 of the SEC.
+		 * If we go much over that, we might cause purging.
+		 * This is mainly an issue when max_bytes is small (256K)
+		 * and size is large. For larger max_bytes, we will
+		 * almost always end up with MAX_SEC_NALLOCS.
+		 */
+		res = sec->opts.max_bytes / size / MAX_BYTES_DIV;
+
+		res = (1 <= res) ? res : 1;
+		res = (res <= MAX_SEC_NALLOCS) ? res : MAX_SEC_NALLOCS;
+	}
+
+	/* post-conditions */
+	assert(1 <= res);
+	assert(res <= MAX_SEC_NALLOCS);
+
+	return res;
+}
+
 static edata_t *
 sec_bin_alloc_locked(tsdn_t *tsdn, sec_t *sec, sec_bin_t *bin, size_t size) {
 	malloc_mutex_assert_owner(tsdn, &bin->mtx);

--- a/src/stats.c
+++ b/src/stats.c
@@ -1668,7 +1668,6 @@ stats_general_print(emitter_t *emitter) {
 	OPT_WRITE_SIZE_T("hpa_sec_nshards")
 	OPT_WRITE_SIZE_T("hpa_sec_max_alloc")
 	OPT_WRITE_SIZE_T("hpa_sec_max_bytes")
-	OPT_WRITE_SIZE_T("hpa_sec_batch_fill_extra")
 	OPT_WRITE_BOOL("huge_arena_pac_thp")
 	OPT_WRITE_CHAR_P("metadata_thp")
 	OPT_WRITE_INT64("mutex_max_spin")

--- a/test/unit/hpa_sec_integration.c
+++ b/test/unit/hpa_sec_integration.c
@@ -156,12 +156,11 @@ TEST_BEGIN(test_hpa_sec) {
 
 	hpa_shard_opts_t opts = test_hpa_shard_opts;
 
-	enum { NALLOCS = 8 };
+	enum { NALLOCS = 16 };
 	sec_opts_t sec_opts;
 	sec_opts.nshards = 1;
 	sec_opts.max_alloc = 2 * PAGE;
 	sec_opts.max_bytes = NALLOCS * PAGE;
-	sec_opts.batch_fill_extra = 4;
 
 	hpa_shard_t *shard = create_test_data(&hooks, &opts, &sec_opts);
 	bool         deferred_work_generated = false;
@@ -174,10 +173,9 @@ TEST_BEGIN(test_hpa_sec) {
 	hpa_shard_stats_t hpa_stats;
 	memset(&hpa_stats, 0, sizeof(hpa_shard_stats_t));
 	hpa_shard_stats_merge(tsdn, shard, &hpa_stats);
-	expect_zu_eq(hpa_stats.psset_stats.merged.nactive,
-	    1 + sec_opts.batch_fill_extra, "");
-	expect_zu_eq(hpa_stats.secstats.bytes, PAGE * sec_opts.batch_fill_extra,
-	    "sec should have fill extra pages");
+	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, 2, "");
+	expect_zu_eq(
+	    hpa_stats.secstats.bytes, PAGE, "sec should have fill extra pages");
 
 	/* Alloc/dealloc NALLOCS times and confirm extents are in sec. */
 	edata_t *edatas[NALLOCS];
@@ -188,8 +186,9 @@ TEST_BEGIN(test_hpa_sec) {
 	}
 	memset(&hpa_stats, 0, sizeof(hpa_shard_stats_t));
 	hpa_shard_stats_merge(tsdn, shard, &hpa_stats);
-	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, 2 + NALLOCS, "");
-	expect_zu_eq(hpa_stats.secstats.bytes, PAGE, "2 refills (at 0 and 4)");
+	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, (2 + NALLOCS), "");
+	expect_zu_eq(hpa_stats.secstats.bytes, PAGE,
+	    "multiple refillts (every 2 allocations)");
 
 	for (int i = 0; i < NALLOCS - 1; i++) {
 		pai_dalloc(
@@ -201,13 +200,14 @@ TEST_BEGIN(test_hpa_sec) {
 	expect_zu_eq(
 	    hpa_stats.secstats.bytes, sec_opts.max_bytes, "sec should be full");
 
-	/* this one should flush 1 + 0.25 * 8 = 3 extents */
+	/* this one should flush 1 + 0.25 * 16 = 5 extents */
 	pai_dalloc(
 	    tsdn, &shard->pai, edatas[NALLOCS - 1], &deferred_work_generated);
 	memset(&hpa_stats, 0, sizeof(hpa_shard_stats_t));
 	hpa_shard_stats_merge(tsdn, shard, &hpa_stats);
-	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, (NALLOCS - 1), "");
-	expect_zu_eq(hpa_stats.psset_stats.merged.ndirty, 3, "");
+	expect_zu_eq(
+	    hpa_stats.psset_stats.merged.nactive, (2 + NALLOCS - 5), "");
+	expect_zu_eq(hpa_stats.psset_stats.merged.ndirty, 5, "");
 	expect_zu_eq(hpa_stats.secstats.bytes, 0.75 * sec_opts.max_bytes,
 	    "sec should be full");
 
@@ -217,7 +217,8 @@ TEST_BEGIN(test_hpa_sec) {
 	expect_ptr_not_null(edata2, "Unexpected null edata");
 	memset(&hpa_stats, 0, sizeof(hpa_shard_stats_t));
 	hpa_shard_stats_merge(tsdn, shard, &hpa_stats);
-	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, NALLOCS - 1, "");
+	expect_zu_eq(
+	    hpa_stats.psset_stats.merged.nactive, (2 + NALLOCS - 5), "");
 	expect_zu_eq(hpa_stats.secstats.bytes, 0.75 * sec_opts.max_bytes - PAGE,
 	    "sec should have max_bytes minus one page that just came from it");
 
@@ -225,8 +226,9 @@ TEST_BEGIN(test_hpa_sec) {
 	pai_dalloc(tsdn, &shard->pai, edata2, &deferred_work_generated);
 	memset(&hpa_stats, 0, sizeof(hpa_shard_stats_t));
 	hpa_shard_stats_merge(tsdn, shard, &hpa_stats);
-	expect_zu_eq(hpa_stats.psset_stats.merged.nactive, NALLOCS - 1, "");
-	expect_zu_eq(hpa_stats.psset_stats.merged.ndirty, 3, "");
+	expect_zu_eq(
+	    hpa_stats.psset_stats.merged.nactive, (2 + NALLOCS - 5), "");
+	expect_zu_eq(hpa_stats.psset_stats.merged.ndirty, 5, "");
 	expect_zu_eq(hpa_stats.secstats.bytes, 0.75 * sec_opts.max_bytes, "");
 
 	destroy_test_data(shard);

--- a/test/unit/mallctl.c
+++ b/test/unit/mallctl.c
@@ -313,7 +313,6 @@ TEST_BEGIN(test_mallctl_opt) {
 	TEST_MALLCTL_OPT(size_t, hpa_sec_nshards, always);
 	TEST_MALLCTL_OPT(size_t, hpa_sec_max_alloc, always);
 	TEST_MALLCTL_OPT(size_t, hpa_sec_max_bytes, always);
-	TEST_MALLCTL_OPT(size_t, hpa_sec_batch_fill_extra, always);
 	TEST_MALLCTL_OPT(ssize_t, experimental_hpa_max_purge_nhp, always);
 	TEST_MALLCTL_OPT(size_t, hpa_purge_threshold, always);
 	TEST_MALLCTL_OPT(uint64_t, hpa_min_purge_delay_ms, always);

--- a/test/unit/sec.c
+++ b/test/unit/sec.c
@@ -69,7 +69,6 @@ TEST_BEGIN(test_sec_fill) {
 	opts.nshards = 1;
 	opts.max_alloc = 2 * PAGE;
 	opts.max_bytes = 4 * PAGE;
-	opts.batch_fill_extra = 2;
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	test_data_init(tsdn, &tdata, &opts);
@@ -114,7 +113,6 @@ TEST_BEGIN(test_sec_alloc) {
 	opts.nshards = 1;
 	opts.max_alloc = 2 * PAGE;
 	opts.max_bytes = 4 * PAGE;
-	opts.batch_fill_extra = 1;
 
 	tsdn_t *tsdn = tsd_tsdn(tsd_fetch());
 	test_data_init(tsdn, &tdata, &opts);


### PR DESCRIPTION
Remove bach_fill_extra field (and associated setters) and calculate nallocs based on misses. The more recorded misses, the higher the nallocs number up to a maximum.